### PR TITLE
[Feature & Bug Fix] Support train by epoch

### DIFF
--- a/docs/apis/config.md
+++ b/docs/apis/config.md
@@ -12,7 +12,11 @@
 
     * batch_size: 更新的batch_size，可以不指定
 
-    * iters: 更新的训练轮次，可以不指定
+    * iters: 更新的训练步数，可以不指定
+
+    * epochs: 更新的训练轮次，可以不指定
+
+    *注意：使用一个 batch 数据对模型进行一次参数更新的过程称之为一步，iters 即为训练过程中的训练步数。完整遍历一次数据对模型进行训练的过程称之为一次迭代，epochs 即为训练过程中的训练迭代次数。一个epoch包含多个iter。*
 
   * **异常值**
 
@@ -32,7 +36,9 @@
 
     * batch_size: 更新的batch_size，可以不指定
 
-    * iters: 更新的训练轮次，可以不指定
+    * iters: 更新的训练步数，可以不指定
+
+    * epochs: 更新的训练轮次，可以不指定
 
 ## to_dict
 
@@ -43,6 +49,10 @@
   单卡batch_size大小
 
 ## iters
+
+  训练步数，与epochs互斥，当指定iters时，epochs不生效
+
+## epochs
 
   训练轮次
 

--- a/docs/apis/trainer.md
+++ b/docs/apis/trainer.md
@@ -8,7 +8,9 @@
 
       * model: 待训练或者评估的模型
 
-      * iters: 训练轮次
+      * iters: 更新的训练步数，可以不指定，与epochs互斥，当指定iters时，epochs不生效
+
+      * epochs: 更新的训练轮次，可以不指定
 
       * optimizer: 训练所用的优化器
 
@@ -35,6 +37,8 @@
         *  `dict` 类型，指定构建默认 Dataloader 类对象的参数，如 `batch_size` / `drop_last` / `shuffle` 。
 
         * 继承了 `paddle3d.apis.CheckpointABC` 的类对象
+
+      *注意：使用一个 batch 数据对模型进行一次参数更新的过程称之为一步，iters 即为训练过程中的训练步数。完整遍历一次数据对模型进行训练的过程称之为一次迭代，epochs 即为训练过程中的训练迭代次数。一个epoch包含多个iter。*
 
   * **异常值**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,8 @@ Paddle3D支持通过配置文件来描述相关的任务，从而实现配置化
 |train_dataset |训练数据集 | dict |
 |val_dataset |验证数据集 | dict  |
 |batch_size|单张卡上，每步迭代训练时的数据量。一般来说，单步训练时的batch_size越大，则样本整体梯度更加稳定，有利于模型的收敛，调大batch_size时往往需要适当调大learning_rate | int |
-|iters| 使用一个 batch 数据对模型进行一次参数更新的过程称之为一次迭代，iters 即为训练过程中的迭代次数。 | int|
+|iters| 使用一个 batch 数据对模型进行一次参数更新的过程称之为一步，iters 即为训练过程中的训练步数。 | int|
+|epochs| 完整遍历一次数据对模型进行训练的过程称之为一次迭代，epochs 即为训练过程中的训练迭代次数。一个epoch包含多个iter | int|
 |optimizer|优化器类型，支持飞桨全部的[优化器类型](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/optimizer/Overview_cn.html#paddle-optimizer) | dict|
 |lr_scheduler|调度器类型，支持飞桨全部的[LRScheduler](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/optimizer/lr/LRScheduler_cn.html) |dict|
 |model| 模型类型，所支持值请参考[模型库](./apis/models.md)|dict|

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,7 +31,8 @@ fleetrun tools/train.py --config configs/smoke/smoke_dla34_no_dcn_iter70000.yml 
 
 | 参数名              | 用途                                                         | 是否必选项  | 默认值            |
 | :------------------ | :----------------------------------------------------------- | :--------- | :--------------- |
-| iters               | 训练迭代次数                                                  | 否         | 配置文件中指定值  |
+| iters               | 训练迭代步数                                                  | 否         | 配置文件中指定值  |
+| epochs               | 训练迭代次数                                                  | 否         | 配置文件中指定值  |
 | batch_size          | 单卡batch size                                               | 否         | 配置文件中指定值   |
 | learning_rate       | 初始学习率                                                    | 否         | 配置文件中指定值  |
 | config              | 配置文件路径                                                  | 是         | -                |
@@ -43,6 +44,8 @@ fleetrun tools/train.py --config configs/smoke/smoke_dla34_no_dcn_iter70000.yml 
 | resume              | 是否从检查点中恢复数据，如：`output/iter_1000`                 | 否          | None             |
 | keep_checkpoint_max | 最新模型保存个数                                              | 否          | 5                |
 | seed                | Paddle的全局随机种子值                                                    | 否         | None              |
+
+*注意：使用一个 batch 数据对模型进行一次参数更新的过程称之为一步，iters 即为训练过程中的训练步数。完整遍历一次数据对模型进行训练的过程称之为一次迭代，epochs 即为训练过程中的训练迭代次数。一个epoch包含多个iter。*
 
 <br>
 

--- a/paddle3d/apis/config.py
+++ b/paddle3d/apis/config.py
@@ -29,6 +29,7 @@ class Config(object):
     The following hyper-parameters are available in the config file:
         batch_size: The number of samples per gpu.
         iters: The total training steps.
+        epochs: The total training epochs.
         train_dataset: A training data config including type/data_root/transforms/mode.
             For data type, please refer to paddle3d.datasets.
             For specific transforms, please refer to paddle3d.transforms.transforms.
@@ -61,7 +62,8 @@ class Config(object):
                  path: str,
                  learning_rate: Optional[float] = None,
                  batch_size: Optional[int] = None,
-                 iters: Optional[int] = None):
+                 iters: Optional[int] = None,
+                 epochs: Optional[int] = None):
         if not path:
             raise ValueError('Please specify the configuration file path.')
 
@@ -77,7 +79,10 @@ class Config(object):
             raise RuntimeError('Config file should in yaml format!')
 
         self.update(
-            learning_rate=learning_rate, batch_size=batch_size, iters=iters)
+            learning_rate=learning_rate,
+            batch_size=batch_size,
+            iters=iters,
+            epochs=epochs)
 
     def _update_dic(self, dic: Dict, base_dic: Dict):
         '''Update config from dic based base_dic
@@ -115,17 +120,21 @@ class Config(object):
     def update(self,
                learning_rate: Optional[float] = None,
                batch_size: Optional[int] = None,
-               iters: Optional[int] = None):
+               iters: Optional[int] = None,
+               epochs: Optional[int] = None):
         '''Update config'''
 
-        if learning_rate:
+        if learning_rate is not None:
             self.dic['lr_scheduler']['learning_rate'] = learning_rate
 
-        if batch_size:
+        if batch_size is not None:
             self.dic['batch_size'] = batch_size
 
-        if iters:
+        if iters is not None:
             self.dic['iters'] = iters
+
+        if epochs is not None:
+            self.dic['epochs'] = epochs
 
     @property
     def batch_size(self) -> int:
@@ -134,9 +143,12 @@ class Config(object):
     @property
     def iters(self) -> int:
         iters = self.dic.get('iters')
-        if not iters:
-            raise RuntimeError('No iters specified in the configuration file.')
         return iters
+
+    @property
+    def epochs(self) -> int:
+        epochs = self.dic.get('epochs')
+        return epochs
 
     @property
     def lr_scheduler(self) -> paddle.optimizer.lr.LRScheduler:
@@ -285,13 +297,17 @@ class Config(object):
         return msg
 
     def to_dict(self) -> Dict:
-        dic = {
+        if self.iters is not None:
+            dic = {'iters': self.iters}
+        else:
+            dic = {'epochs': self.epochs}
+
+        dic.update({
             'optimizer': self.optimizer,
             'model': self.model,
             'train_dataset': self.train_dataset,
             'val_dataset': self.val_dataset,
-            'iters': self.iters,
             'batch_size': self.batch_size
-        }
+        })
 
         return dic

--- a/paddle3d/apis/trainer.py
+++ b/paddle3d/apis/trainer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-from typing import Callable, Union
+from typing import Callable, Optional, Union
 
 import paddle
 from visualdl import LogWriter
@@ -77,9 +77,14 @@ def default_scheduler_build_fn(**kwargs) -> Scheduler:
     """
     """
     kwargs = kwargs.copy()
-    kwargs.setdefault('save_interval', 1000)
     kwargs.setdefault('log_interval', 10)
     kwargs.setdefault('do_eval', False)
+
+    if kwargs.get('train_by_epoch'):
+        kwargs.setdefault('save_interval', 5)
+    else:
+        kwargs.setdefault('save_interval', 1000)
+
     return Scheduler(**kwargs)
 
 
@@ -90,10 +95,11 @@ class Trainer:
     def __init__(
             self,
             model: paddle.nn.Layer,
-            iters: int,
             optimizer: paddle.optimizer.Optimizer,
-            train_dataset: paddle.io.Dataset,
-            val_dataset: paddle.io.Dataset = None,
+            iters: Optional[int] = None,
+            epochs: Optional[int] = None,
+            train_dataset: Optional[paddle.io.Dataset] = None,
+            val_dataset: Optional[paddle.io.Dataset] = None,
             resume: bool = False,
             # TODO: Default parameters should not use mutable objects, there is a risk
             checkpoint: Union[dict, CheckpointABC] = dict(),
@@ -102,18 +108,6 @@ class Trainer:
 
         self.model = model
         self.optimizer = optimizer
-        self.iters = iters
-        self.cur_iter = 0
-        self.resume = resume
-        vdl_file_name = None
-
-        if self.optimizer.__class__.__name__ == 'OneCycleAdam':
-            self.optimizer.before_run(max_iters=self.iters)
-
-        self.checkpoint = default_checkpoint_build_fn(
-            **checkpoint) if isinstance(checkpoint, dict) else checkpoint
-        self.scheduler = default_scheduler_build_fn(
-            **scheduler) if isinstance(scheduler, dict) else scheduler
 
         _dataloader_build_fn = default_dataloader_build_fn(
             **dataloader_fn) if isinstance(dataloader_fn,
@@ -124,6 +118,35 @@ class Trainer:
             val_dataset, self.model) if val_dataset else None
         self.val_dataset = val_dataset
 
+        self.resume = resume
+        vdl_file_name = None
+        self.iters_per_epoch = len(self.train_dataloader)
+
+        if iters is None:
+            self.epochs = epochs
+            self.iters = epochs * self.iters_per_epoch
+            self.train_by_epoch = True
+        else:
+            self.iters = iters
+            self.epochs = (iters - 1) // self.iters_per_epoch + 1
+            self.train_by_epoch = False
+
+        self.cur_iter = 0
+        self.cur_epoch = 0
+
+        if self.optimizer.__class__.__name__ == 'OneCycleAdam':
+            self.optimizer.before_run(max_iters=self.iters)
+
+        self.checkpoint = default_checkpoint_build_fn(
+            **checkpoint) if isinstance(checkpoint, dict) else checkpoint
+
+        if isinstance(scheduler, dict):
+            scheduler.setdefault('train_by_epoch', self.train_by_epoch)
+            scheduler.setdefault('iters_per_epoch', self.iters_per_epoch)
+            self.scheduler = default_scheduler_build_fn(**scheduler)
+        else:
+            self.scheduler = scheduler
+
         if self.checkpoint is None:
             return
 
@@ -133,10 +156,18 @@ class Trainer:
                     'The checkpoint {} is not emtpy! Set `resume=True` to continue training or use another dir as checkpoint'
                     .format(self.checkpoint.rootdir))
 
+            if self.checkpoint.meta.get(
+                    'train_by_epoch') != self.train_by_epoch:
+                raise RuntimeError(
+                    'Unable to resume training since the train_by_epoch is inconsistent with that saved in the checkpoint'
+                )
+
             params_dict, opt_dict = self.checkpoint.get()
             self.model.set_dict(params_dict)
             self.optimizer.set_state_dict(opt_dict)
             self.cur_iter = self.checkpoint.meta.get('iters')
+            self.cur_epoch = self.checkpoint.meta.get('epochs')
+            self.scheduler.step(self.cur_iter)
 
             logger.info(
                 'Resume model from checkpoint {}, current iter set to {}'.
@@ -151,6 +182,7 @@ class Trainer:
                 logdir=self.checkpoint.rootdir, file_name=vdl_file_name)
             self.checkpoint.record('vdl_file_name',
                                    os.path.basename(self.log_writer.file_name))
+            self.checkpoint.record('train_by_epoch', self.train_by_epoch)
 
     def train(self):
         """
@@ -175,6 +207,10 @@ class Trainer:
 
             for sample in self.train_dataloader:
                 self.cur_iter += 1
+
+                if self.cur_iter % self.iters_per_epoch == 1:
+                    self.cur_epoch += 1
+
                 if self.cur_iter > self.iters:
                     break
 
@@ -189,9 +225,9 @@ class Trainer:
                     lr = self.optimizer.get_lr()
                     loss_sum = float(loss_sum / self.scheduler.log_interval)
                     logger.info(
-                        '[TRAIN] iter={}/{}, loss={:.6f}, lr={:.6f} | ETA {}'.
-                        format(self.cur_iter, self.iters, loss_sum, lr,
-                               timer.eta))
+                        '[TRAIN] epoch={}/{}, iter={}/{}, loss={:.6f}, lr={:.6f} | ETA {}'
+                        .format(self.cur_epoch, self.epochs, self.cur_iter,
+                                self.iters, loss_sum, lr, timer.eta))
 
                     self.log_writer.add_scalar(
                         tag='Training/learning_rate',
@@ -202,39 +238,48 @@ class Trainer:
 
                     loss_sum = 0
 
+                if status.do_eval:
+                    # TODO: whether to save a checkpoint based on the metric
+                    metrics = self.evaluate()
+                    for k, v in metrics.items():
+                        if not isinstance(v, paddle.Tensor) or v.numel() != 1:
+                            continue
+
+                        self.log_writer.add_scalar(
+                            tag='Evaluation/{}'.format(k),
+                            value=float(v),
+                            step=self.cur_iter)
+
                 if status.save_checkpoint and env.local_rank == 0:
-
-                    if status.do_eval:
-                        # TODO: whether to save a checkpoint based on the metric
-                        metrics = self.evaluate()
-                        for k, v in metrics.items():
-                            if isinstance(v, paddle.Tensor) and v.numel() == 1:
-                                self.log_writer.add_scalar(
-                                    tag='Evaluation/{}'.format(k),
-                                    value=float(v),
-                                    step=self.cur_iter)
-
-                    dic = {
-                        'params_dict': model.state_dict(),
-                        'opt_dict': self.optimizer.state_dict()
-                    }
+                    if self.train_by_epoch:
+                        tag = 'epoch_{}'.format(self.cur_epoch)
+                    else:
+                        tag = 'iter_{}'.format(self.cur_iter)
 
                     self.checkpoint.push(
-                        **dic,
-                        tag='iter_{}'.format(self.cur_iter),
+                        tag=tag,
+                        params_dict=self.model.state_dict(),
+                        opt_dict=self.optimizer.state_dict(),
                         verbose=True)
+
                     self.checkpoint.record('iters', self.cur_iter)
+                    self.checkpoint.record('epochs', self.cur_epoch)
 
         logger.info('Training is complete.')
-        last_checkpoint = 'iter_{}'.format(self.iters)
-        if not self.checkpoint.have(last_checkpoint):
-            dic = {
-                'params_dict': self.model.state_dict(),
-                'opt_dict': self.optimizer.state_dict()
-            }
-            self.checkpoint.push(**dic, tag=last_checkpoint, verbose=True)
+        if self.train_by_epoch:
+            tag = 'epoch_{}'.format(self.epochs)
+        else:
+            tag = 'iter_{}'.format(self.iters)
+
+        if not self.checkpoint.have(tag):
+            self.checkpoint.push(
+                tag=tag,
+                params_dict=self.model.state_dict(),
+                opt_dict=self.optimizer.state_dict(),
+                verbose=True)
 
         self.checkpoint.record('iters', self.iters)
+        self.checkpoint.record('epochs', self.epochs)
 
     def evaluate(self) -> float:
         """

--- a/tools/train.py
+++ b/tools/train.py
@@ -50,6 +50,12 @@ def parse_args():
         type=int,
         default=None)
     parser.add_argument(
+        '--epochs',
+        dest='epochs',
+        help='epochs for training',
+        type=int,
+        default=None)
+    parser.add_argument(
         '--keep_checkpoint_max',
         dest='keep_checkpoint_max',
         help='Maximum number of checkpoints to save',
@@ -87,7 +93,8 @@ def parse_args():
     parser.add_argument(
         '--save_interval',
         dest='save_interval',
-        help='How many iters to save a model snapshot once during training.',
+        help=
+        'How many iters/epochs to save a model snapshot once during training.',
         type=int,
         default=1000)
     parser.add_argument(
@@ -122,6 +129,7 @@ def main(args):
         path=args.cfg,
         learning_rate=args.learning_rate,
         iters=args.iters,
+        epochs=args.epochs,
         batch_size=args.batch_size)
 
     if cfg.train_dataset is None:


### PR DESCRIPTION
## New Feature
* Support specifying epochs in the configuration file or train.py to train with epochs.
* When training by epochs, the interval unit of save_interval is epoch rather than iter.
* When both iters and epochs are specified, iters has higher priority.

## Bug Fix
* Restoring scheduler progress from state saved in checkpoints.