### PR TITLE
[Feature] Support for building custom op just-in-time

### DIFF
--- a/paddle3d/ops/__init__.py
+++ b/paddle3d/ops/__init__.py
@@ -24,26 +24,33 @@ from paddle3d.utils.logger import logger
 
 custom_ops = {
     'voxelize': {
-        'sources': ['voxel/voxelize_op.cc', 'voxel/voxelize_op.cu']
+        'sources': ['voxel/voxelize_op.cc', 'voxel/voxelize_op.cu'],
+        'version': '0.1.0',
     },
     'iou3d_nms_cuda': {
         'sources': [
             'iou3d_nms/iou3d_cpu.cpp', 'iou3d_nms/iou3d_nms_api.cpp',
             'iou3d_nms/iou3d_nms.cpp', 'iou3d_nms/iou3d_nms_kernel.cu'
-        ]
+        ],
+        'version':
+        '0.1.0',
     },
     'centerpoint_postprocess': {
         'sources': [
             'centerpoint_postprocess/iou3d_nms_kernel.cu',
             'centerpoint_postprocess/postprocess.cc',
             'centerpoint_postprocess/postprocess.cu'
-        ]
+        ],
+        'version':
+        '0.1.0',
     },
     'grid_sample_3d': {
         'sources': [
             'grid_sample_3d/grid_sample_3d.cc',
             'grid_sample_3d/grid_sample_3d.cu'
-        ]
+        ],
+        'version':
+        '0.1.0',
     }
 }
 
@@ -95,6 +102,8 @@ class Paddle3dCustomOperatorModule(ModuleType):
             args = custom_ops[self.modulename].copy()
             sources = args.pop('sources')
             sources = [os.path.join(rootdir, file) for file in sources]
+
+            args.pop('version')
             return paddle_jit_load(
                 name=self.modulename, sources=sources, **args)
         except:

--- a/paddle3d/ops/__init__.py
+++ b/paddle3d/ops/__init__.py
@@ -105,7 +105,7 @@ class Paddle3dCustomOperatorModule(ModuleType):
             except ImportError:
                 logger.warning("No custom op {} found, try JIT build".format(
                     self.modulename))
-                self.jit_build()
+                self.module = self.jit_build()
                 logger.info("{} builded success!".format(self.modulename))
 
         return self.module

--- a/paddle3d/ops/__init__.py
+++ b/paddle3d/ops/__init__.py
@@ -55,7 +55,7 @@ custom_ops = {
 }
 
 
-class UnknownCustomOpException(Exception):
+class CustomOpNotFoundException(Exception):
     def __init__(self, op_name):
         self.op_name = op_name
 
@@ -76,7 +76,7 @@ class CustomOperatorPathLoader:
         modulename = fullname.split('.')[-1]
 
         if modulename not in custom_ops:
-            raise UnknownCustomOpException(modulename)
+            raise CustomOpNotFoundException(modulename)
 
         if fullname not in sys.modules:
             try:

--- a/paddle3d/ops/__init__.py
+++ b/paddle3d/ops/__init__.py
@@ -13,8 +13,47 @@
 # limitations under the License.
 
 import importlib
+import inspect
+import os
 import sys
 from types import ModuleType
+
+from paddle.utils.cpp_extension import load as paddle_jit_load
+
+from paddle3d.utils.logger import logger
+
+custom_ops = {
+    'voxelize': {
+        'sources': ['voxel/voxelize_op.cc', 'voxel/voxelize_op.cu']
+    },
+    'iou3d_nms_cuda': {
+        'sources': [
+            'iou3d_nms/iou3d_cpu.cpp', 'iou3d_nms/iou3d_nms_api.cpp',
+            'iou3d_nms/iou3d_nms.cpp', 'iou3d_nms/iou3d_nms_kernel.cu'
+        ]
+    },
+    'centerpoint_postprocess': {
+        'sources': [
+            'centerpoint_postprocess/iou3d_nms_kernel.cu',
+            'centerpoint_postprocess/postprocess.cc',
+            'centerpoint_postprocess/postprocess.cu'
+        ]
+    },
+    'grid_sample_3d': {
+        'sources': [
+            'grid_sample_3d/grid_sample_3d.cc',
+            'grid_sample_3d/grid_sample_3d.cu'
+        ]
+    }
+}
+
+
+class UnknownCustomOpException(Exception):
+    def __init__(self, op_name):
+        self.op_name = op_name
+
+    def __str__(self):
+        return "Couldn't Found custom op {}".format(self.op_name)
 
 
 class CustomOperatorPathFinder:
@@ -28,6 +67,10 @@ class CustomOperatorPathFinder:
 class CustomOperatorPathLoader:
     def load_module(self, fullname: str):
         modulename = fullname.split('.')[-1]
+
+        if modulename not in custom_ops:
+            raise UnknownCustomOpException(modulename)
+
         sys.modules[fullname] = Paddle3dCustomOperatorModule(
             modulename, fullname)
         return sys.modules[fullname]
@@ -40,10 +83,30 @@ class Paddle3dCustomOperatorModule(ModuleType):
         self.module = None
         super().__init__(modulename)
 
+    def jit_build(self):
+        try:
+            file = inspect.getabsfile(sys.modules['paddle3d.ops'])
+            rootdir = os.path.split(file)[0]
+
+            args = custom_ops[self.modulename].copy()
+            sources = args.pop('sources')
+            sources = [os.path.join(rootdir, file) for file in sources]
+            return paddle_jit_load(
+                name=self.modulename, sources=sources, **args)
+        except:
+            logger.error("{} builded fail!".format(self.modulename))
+            raise
+
     def _load_module(self):
         if self.module is None:
-            self.module = importlib.import_module(self.modulename)
-            sys.modules[self.fullname] = self.module
+            try:
+                self.module = importlib.import_module(self.modulename)
+                sys.modules[self.fullname] = self.module
+            except ImportError:
+                logger.warning("No custom op {} found, try JIT build".format(
+                    self.modulename))
+                self.jit_build()
+                logger.info("{} builded success!".format(self.modulename))
 
         return self.module
 

--- a/paddle3d/ops/setup.py
+++ b/paddle3d/ops/setup.py
@@ -4,7 +4,7 @@ from paddle.utils.cpp_extension import CppExtension, CUDAExtension, setup
 from paddle3d.ops import custom_ops
 
 for op_name, op_dict in custom_ops.items():
-    sources = op_dict.get('sources', [])
+    sources = op_dict.pop('sources', [])
     flags = None
 
     if paddle.device.is_compiled_with_cuda():
@@ -18,4 +18,8 @@ for op_name, op_dict in custom_ops.items():
         continue
 
     extension = extension(sources=sources)
-    setup(name=op_name, ext_modules=extension, extra_compile_args=flags)
+    setup(
+        name=op_name,
+        ext_modules=extension,
+        extra_compile_args=flags,
+        **op_dict)

--- a/paddle3d/ops/setup.py
+++ b/paddle3d/ops/setup.py
@@ -1,43 +1,9 @@
 import paddle
 from paddle.utils.cpp_extension import CppExtension, CUDAExtension, setup
 
-custom_ops = [
-    # voxelize
-    {
-        'name': 'voxelize',
-        'sources': ['voxel/voxelize_op.cc', 'voxel/voxelize_op.cu']
-    },
-    # iou3d_nms
-    {
-        'name':
-        'iou3d_nms_cuda',
-        'sources': [
-            'iou3d_nms/iou3d_cpu.cpp', 'iou3d_nms/iou3d_nms_api.cpp',
-            'iou3d_nms/iou3d_nms.cpp', 'iou3d_nms/iou3d_nms_kernel.cu'
-        ]
-    },
-    # centerpoint_postprocess
-    {
-        'name':
-        'centerpoint_postprocess',
-        'sources': [
-            'centerpoint_postprocess/iou3d_nms_kernel.cu',
-            'centerpoint_postprocess/postprocess.cc',
-            'centerpoint_postprocess/postprocess.cu'
-        ]
-    },
-    # grid_sample_3d
-    {
-        'name':
-        'grid_sample_3d',
-        'sources': [
-            'grid_sample_3d/grid_sample_3d.cc',
-            'grid_sample_3d/grid_sample_3d.cu'
-        ]
-    }
-]
+from paddle3d.ops import custom_ops
 
-for op_dict in custom_ops:
+for op_name, op_dict in custom_ops.items():
     sources = op_dict.get('sources', [])
     flags = None
 
@@ -52,4 +18,4 @@ for op_dict in custom_ops:
         continue
 
     extension = extension(sources=sources)
-    setup(name=op_dict['name'], ext_modules=extension, extra_compile_args=flags)
+    setup(name=op_name, ext_modules=extension, extra_compile_args=flags)


### PR DESCRIPTION
## Feature
* Running an uncompiled custom op will trigger just-in-time build
* Add version in custom op
* A `CustomOpNotFoundException` is thrown when trying to load a custom op that doesn't exist
* If a custom op already exists locally, then the delayed import operation is not performed