### PR TITLE
[Bug Fix] set default value of existing_difficulties and ignored_bboxes_3d for SamplingDatabase

### DIFF
--- a/paddle3d/transforms/detection.py
+++ b/paddle3d/transforms/detection.py
@@ -382,11 +382,10 @@ class SamplingDatabase(TransformABC):
             existing_velocities = sample.bboxes_3d.velocities.copy()
         existing_labels = sample.labels.copy()
         existing_data = sample.data.copy()
-        existing_difficulties = getattr(sample, "difficulties", None)
-        ignored_bboxes_3d = getattr(
-            sample, "ignored_bboxes_3d",
-            np.zeros([0, existing_bboxes_3d.shape[1]],
-                     dtype=existing_bboxes_3d.dtype))
+        existing_difficulties = None if "difficulties" not in sample else sample.difficulties
+        ignored_bboxes_3d = np.zeros(
+            [0, existing_bboxes_3d.shape[1]], dtype=existing_bboxes_3d.dtype
+        ) if "ignored_bboxes_3d" not in sample else sample.ignored_bboxes_3d
         avoid_coll_bboxes_3d = np.vstack(
             [existing_bboxes_3d, ignored_bboxes_3d])
 


### PR DESCRIPTION
# Bug Fix

Class `Sample` cannot use `getattr(sample, "difficulties", None)` when it does not have "difficulties" attributed, so we replace it with:
```
None if "difficulties" not in sample else sample.difficulties
```