### PR TITLE
[Bug Fix] Fix the bug that EasyDict not throwing AttributeError correctly

### DIFF
--- a/paddle3d/sample.py
+++ b/paddle3d/sample.py
@@ -17,7 +17,9 @@ from typing import Generic, List, Optional
 
 class _EasyDict(dict):
     def __getattr__(self, key: str):
-        return self[key]
+        if key in self:
+            return self[key]
+        return super().__getattr__(self, key)
 
     def __setattr__(self, key: str, value: Generic):
         self[key] = value


### PR DESCRIPTION
## Bug
* Fixed bug where EasyDict did not properly throw AttributeError causing getattr to not work properly.
  ```python
  Python 3.6.13 |Anaconda, Inc.| (default, Jun  4 2021, 14:25:59) 
  [GCC 7.5.0] on linux
  Type "help", "copyright", "credits" or "license" for more information.
  >>> from paddle3d.sample import _EasyDict
  >>> a = _EasyDict()
  >>> getattr(a, '1', None)
  Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
    File "/home/wuzewu/code/Paddle3D/paddle3d/sample.py", line 21, in __getattr__
      return self[key]
  KeyError: '1'
  ```