### PR TITLE
[Bug Fix] Fix smoke eval bug

### DIFF
--- a/configs/smoke/smoke_dla34_no_dcn_iter70000.yml
+++ b/configs/smoke/smoke_dla34_no_dcn_iter70000.yml
@@ -11,6 +11,7 @@ train_dataset:
     - type: Gt2SmokeTarget
       mode: train
       num_classes: 3
+      input_size: [1280, 384]
     - type: Normalize
       mean: [0.485, 0.456, 0.406]
       std: [0.229, 0.224, 0.225]
@@ -23,6 +24,7 @@ val_dataset:
     - type: Gt2SmokeTarget
       mode: val
       num_classes: 3
+      input_size: [1280, 384]
     - type: Normalize
       mean: [0.485, 0.456, 0.406]
       std: [0.229, 0.224, 0.225]

--- a/configs/smoke/smoke_hrnet18_no_dcn_iter70000.yml
+++ b/configs/smoke/smoke_hrnet18_no_dcn_iter70000.yml
@@ -11,6 +11,7 @@ train_dataset:
     - type: Gt2SmokeTarget
       mode: train
       num_classes: 3
+      input_size: [1280, 384]
     - type: Normalize
       mean: [0.485, 0.456, 0.406]
       std: [0.229, 0.224, 0.225]
@@ -23,6 +24,7 @@ val_dataset:
     - type: Gt2SmokeTarget
       mode: val
       num_classes: 3
+      input_size: [1280, 384]
     - type: Normalize
       mean: [0.485, 0.456, 0.406]
       std: [0.229, 0.224, 0.225]

--- a/deploy/smoke/cpp/infer.cpp
+++ b/deploy/smoke/cpp/infer.cpp
@@ -29,8 +29,8 @@ DEFINE_string(dynamic_shape_file, "dynamic_shape_info.txt", "Path of a dynamic s
 void get_image(const std::string& image, float* data) {
     cv::Mat img = cv::imread(image, cv::IMREAD_COLOR);
 
-    //cv::cvtColor(img, img, cv::COLOR_BGR2RGB);
-    cv::resize(img, img, cv::Size(960, 640));
+    cv::cvtColor(img, img, cv::COLOR_BGR2RGB);
+    cv::resize(img, img, cv::Size(1280, 384));
     //Normalize
     img.convertTo(img, CV_32F, 1.0 / 255, 0);
 
@@ -133,14 +133,14 @@ int main(int argc, char *argv[]) {
 
     auto predictor = InitPredictor();
 
-    std::vector<int> input_im_shape = {1, 3, 640, 960};
-    std::vector<float> input_im_data(1 * 3 * 640 * 960);
+    std::vector<int> input_im_shape = {1, 3, 384, 1280};
+    std::vector<float> input_im_data(1 * 3 * 384 * 1280);
     get_image(FLAGS_image, input_im_data.data());
 
     std::vector<int> input_K_shape = {1, 3, 3};
-    // K is {2055.56, 0, 939.658, 0, 2055.56, 641.072, 0, 0, 1}
-    std::vector<float> input_K_data = {4.8648543e-04, 0, -4.5712993e-01, 0.0, 4.8648543e-04, -3.1187218e-01, 0, 0, 1};
-
+    // Listed below are camera intrinsic parameter of the kitti dataset
+    // If the model is trained on other datasets, please replace the relevant data
+    std::vector<float> input_K_data = {721.53771973, 0., 609.55932617, 0., 721.53771973, 172.85400391, 0, 0, 1};
     std::vector<int> input_ratio_shape = {1, 2};
     std::vector<float> input_ratio_data(8, 8);
 

--- a/deploy/smoke/cpp/infer.cpp
+++ b/deploy/smoke/cpp/infer.cpp
@@ -24,8 +24,6 @@ DEFINE_int32(trt_precision, 0, "Precision type of tensorrt, 0: kFloat32, 1: kInt
 DEFINE_bool(collect_dynamic_shape_info, false, "Whether to collect dynamic shape before using tensorrt");
 DEFINE_string(dynamic_shape_file, "dynamic_shape_info.txt", "Path of a dynamic shape file for tensorrt");
 
-
-
 void get_image(const std::string& image, float* data) {
     cv::Mat img = cv::imread(image, cv::IMREAD_COLOR);
 

--- a/deploy/smoke/python/infer.py
+++ b/deploy/smoke/python/infer.py
@@ -62,17 +62,18 @@ def get_ratio(ori_img_size, output_size, down_ratio=(4, 4)):
 
 def get_img(img_path):
     img = cv2.imread(img_path)
-    ori_img_size = img.shape
-    img = cv2.resize(img, (960, 640))
-    output_size = img.shape
+    img = cv2.resize(img, (1280, 384))
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+
     img = img / 255.0
     img = np.subtract(img, np.array([0.485, 0.456, 0.406]))
     img = np.true_divide(img, np.array([0.229, 0.224, 0.225]))
     img = np.array(img, np.float32)
+
     img = img.transpose(2, 0, 1)
     img = img[None, :, :, :]
 
-    return img, ori_img_size, output_size
+    return img, img.shape, img.shape
 
 
 def init_predictor(args):
@@ -128,13 +129,16 @@ def run(predictor, img):
 if __name__ == '__main__':
     args = parse_args()
     pred = init_predictor(args)
-    K = np.array([[[2055.56, 0, 939.658], [0, 2055.56, 641.072], [0, 0, 1]]],
-                 np.float32)
-    K_inverse = np.linalg.inv(K)
+    # Listed below are camera intrinsic parameter of the kitti dataset
+    # If the model is trained on other datasets, please replace the relevant data
+    K = np.array([[[721.53771973, 0., 609.55932617],
+                   [0., 721.53771973, 172.85400391], [0, 0, 1]]], np.float32)
 
     img, ori_img_size, output_size = get_img(args.image)
     ratio = get_ratio(ori_img_size, output_size)
 
-    results = run(pred, [img, K_inverse, ratio])
+    results = run(pred, [img, K, ratio])
 
     total_pred = results[0]
+    import pdb
+    pdb.set_trace()

--- a/deploy/smoke/python/infer.py
+++ b/deploy/smoke/python/infer.py
@@ -62,7 +62,10 @@ def get_ratio(ori_img_size, output_size, down_ratio=(4, 4)):
 
 def get_img(img_path):
     img = cv2.imread(img_path)
+    origin_shape = img.shape
     img = cv2.resize(img, (1280, 384))
+
+    target_shape = img.shape
     img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
     img = img / 255.0
@@ -73,7 +76,7 @@ def get_img(img_path):
     img = img.transpose(2, 0, 1)
     img = img[None, :, :, :]
 
-    return img, img.shape, img.shape
+    return img, origin_shape, target_shape
 
 
 def init_predictor(args):

--- a/paddle3d/datasets/kitti/kitti_mono_det.py
+++ b/paddle3d/datasets/kitti/kitti_mono_det.py
@@ -30,11 +30,13 @@ class KittiMonoDataset(KittiDetDataset):
     def __getitem__(self, index: int) -> Sample:
         filename = '{}.png'.format(self.data[index])
         path = os.path.join(self.image_dir, filename)
-        P2 = self.load_calibration_info(index)[2]
+        calibs = self.load_calibration_info(index)
 
         sample = Sample(path=path, modality="image")
-        sample.meta.camera_intrinsic = P2[:3, :3]
+        # P2
+        sample.meta.camera_intrinsic = calibs[2][:3, :3]
         sample.meta.id = self.data[index]
+        sample.calibs = calibs
 
         if not self.is_test_mode:
             kitti_records, ignored_kitti_records = self.load_annotation(index)

--- a/paddle3d/datasets/kitti/kitti_utils.py
+++ b/paddle3d/datasets/kitti/kitti_utils.py
@@ -29,20 +29,17 @@ def camera_record_to_object(
         bboxes_2d = BBoxes2D(np.zeros([0, 4]))
         bboxes_3d = BBoxes3D(
             np.zeros([0, 7]),
-            origin=[.5, .5, .5],
+            origin=[.5, 1, .5],
             coordmode=CoordMode.KittiCamera,
             rot_axis=1)
         labels = []
     else:
-        # from bottom-center to object-center
-        kitti_records[:, 12] = kitti_records[:, 12] - kitti_records[:, 8] / 2
-
         centers = kitti_records[:, 11:14]
         dims = kitti_records[:, 8:11]
         yaws = kitti_records[:, 14:15]
         bboxes_3d = BBoxes3D(
             np.concatenate([centers, dims, yaws], axis=1),
-            origin=[.5, .5, .5],
+            origin=[.5, 1, .5],
             coordmode=CoordMode.KittiCamera,
             rot_axis=1)
         bboxes_2d = BBoxes2D(kitti_records[:, 4:8])

--- a/paddle3d/models/detection/smoke/smoke.py
+++ b/paddle3d/models/detection/smoke/smoke.py
@@ -100,10 +100,7 @@ class SMOKE(nn.Layer):
 
     def _parse_results_to_sample(self, results: paddle.Tensor, sample: dict,
                                  index: int):
-        ret = Sample(sample['path'][index], sample['modality'][index])
-        ret.meta.update(
-            {key: value[index]
-             for key, value in sample['meta'].items()})
+        ret = sample.copy()
         results = results.numpy()
 
         if results.shape[0] != 0:

--- a/paddle3d/models/detection/smoke/smoke.py
+++ b/paddle3d/models/detection/smoke/smoke.py
@@ -20,7 +20,7 @@ import paddle.nn as nn
 import paddle.nn.functional as F
 
 from paddle3d.apis import manager
-from paddle3d.geometries import BBoxes2D, BBoxes3D
+from paddle3d.geometries import BBoxes2D, BBoxes3D, CoordMode
 from paddle3d.models.detection.smoke.processor import PostProcessor
 from paddle3d.models.detection.smoke.smoke_loss import SMOKELossComputation
 from paddle3d.sample import Sample
@@ -109,7 +109,14 @@ class SMOKE(nn.Layer):
         if results.shape[0] != 0:
             clas = results[:, 0]
             bboxes_2d = BBoxes2D(results[:, 2:6])
-            bboxes_3d = BBoxes3D(results[:, 6:13])
+
+            # TODO: fix hard code here
+            bboxes_3d = BBoxes3D(
+                results[:, 6:13],
+                coordmode=CoordMode.KittiCamera,
+                origin=(0.5, 1, 0.5),
+                rot_axis=1)
+
             confidences = results[:, 13]
 
             ret.confidences = confidences

--- a/paddle3d/models/detection/smoke/smoke.py
+++ b/paddle3d/models/detection/smoke/smoke.py
@@ -100,16 +100,21 @@ class SMOKE(nn.Layer):
 
     def _parse_results_to_sample(self, results: paddle.Tensor, sample: dict,
                                  index: int):
-        ret = sample.copy()
-        results = results.numpy()
+        ret = Sample(sample['path'][index], sample['modality'][index])
+        ret.meta.update(
+            {key: value[index]
+             for key, value in sample['meta'].items()})
+        if 'calibs' in sample:
+            ret.calibs = sample['calibs'][index]
 
+        results = results.numpy()
         if results.shape[0] != 0:
             clas = results[:, 0]
             bboxes_2d = BBoxes2D(results[:, 2:6])
 
             # TODO: fix hard code here
             bboxes_3d = BBoxes3D(
-                results[:, 6:13],
+                results[:, [9, 10, 11, 8, 6, 7, 12]],
                 coordmode=CoordMode.KittiCamera,
                 origin=(0.5, 1, 0.5),
                 rot_axis=1)


### PR DESCRIPTION
* The box generated by the Kitti monocular dataset uses the bottom center
* Add calibs to Kitti monocular dataset Sample
* Rearrange the output of the SMOKE model when getting predictions
* Explicitly specify input_size in smoke config file
* Fix bug in infer code:
  * Trans  image from bgr to rgb
  * Use K instead of K_inverse
  * Resize image