### PR TITLE
Fix pillow version invoice the warning message

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ paddledet
 paddleseg
 pyquaternion
 pyyaml
+pillow<=8.3.2
 rarfile
 scikit-image
 visualdl


### PR DESCRIPTION
如果使用最新版本的 Pillow （9.x）会显示如下 Warning：

```bash
DeprecationWarning: FLIP_LEFT_RIGHT is deprecated xxxx
```

我将其进行固定以消除未来可能出现的隐患