### PR TITLE
[FIX BUG] Fix input error :bug:

### DIFF
--- a/paddle3d/thirdparty/kitti_object_eval_python/eval.py
+++ b/paddle3d/thirdparty/kitti_object_eval_python/eval.py
@@ -509,7 +509,7 @@ def eval_class(gt_annos,
     split_parts = get_split_parts(num_examples, num_parts)
 
     rets = calculate_iou_partly(
-        dt_annos, gt_annos, metric, num_parts, z_axis=z_axis, z_center=z_center)
+        gt_annos, dt_annos, metric, num_parts, z_axis=z_axis, z_center=z_center)
     overlaps, parted_overlaps, total_dt_num, total_gt_num = rets
     N_SAMPLE_PTS = 41
     num_minoverlap = len(min_overlaps)


### PR DESCRIPTION
Fix func input bug

`calculate_iou_partly` expected `gt_annos` but input `dt_annos`

```python

def calculate_iou_partly(gt_annos,
                         dt_annos,
                         metric,
                         num_parts=50,
                         z_axis=1,
                         z_center=1.0):
```