### PR TITLE
[cherry-pick] set loaded velocity nan to zero when using nuscenes_devkit<=1.1.9

### DIFF
--- a/paddle3d/datasets/nuscenes/nuscenes_det.py
+++ b/paddle3d/datasets/nuscenes/nuscenes_det.py
@@ -235,7 +235,11 @@ class NuscenesDetDataset(BaseDataset):
                 continue
 
             # add velocity
-            velocities.append(box.velocity[:2])
+            # loaded velocity may be nan when using nuscenes_devkit<=1.1.9
+            # so we reset nan velocity to zero
+            velocity = np.array(box.velocity)
+            velocity[np.isnan(velocity)] = 0
+            velocities.append(velocity[:2])
 
             # get attribute
             clsname = self.LABEL_MAP[anno['category_name']]
@@ -259,6 +263,8 @@ class NuscenesDetDataset(BaseDataset):
                 [x, y, z, w, l, h, -(yaw + np.pi / 2)
                  ],  #TODO(luoqianhui): check this positive sign of yaw
                 dtype=np.float32)
+            # loaded bounding box may be nan when using nuscenes_devkit<=1.1.9
+            # so we reset nan box to zero
             bbox3d[np.isnan(bbox3d)] = 0
             bboxes.append(bbox3d)
             labels.append(label)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ rarfile
 scikit-image
 visualdl
 sklearn
+h5py


### PR DESCRIPTION
cherry-pick #65 

- When using nuscenes_devkit<=1.1.9, loaded velocity from nuscenes datast may be `nan`, which causes the loss to be `nan`. But when using nuscenes_devkit==develop, the corresponding nan velocity is zero when loaded.

  So we set the nan velocity to zero manually.

- add h5py in requirements.txt