### PR TITLE
[Bug Fix] Translate box3d origin before lidar to camera coordinate transform for evaluation

### DIFF
--- a/paddle3d/datasets/kitti/kitti_metric.py
+++ b/paddle3d/datasets/kitti/kitti_metric.py
@@ -103,15 +103,15 @@ class KittiMetric(MetricABC):
 
                 alpha = pred.get('alpha', np.zeros([num_boxes]))
 
+                if pred.bboxes_3d.origin != [.5, .5, 0]:
+                    pred.bboxes_3d[:, :3] += pred.bboxes_3d[:, 3:6] * (
+                        np.array([.5, .5, 0]) - np.array(pred.bboxes_3d.origin))
+                    pred.bboxes_3d.origin = [.5, .5, 0]
+
                 if pred.bboxes_3d.coordmode != CoordMode.KittiCamera:
                     bboxes_3d = box_lidar_to_camera(pred.bboxes_3d, calibs)
                 else:
                     bboxes_3d = pred.bboxes_3d
-
-                if bboxes_3d.origin != [.5, 1., .5]:
-                    bboxes_3d[:, :3] += bboxes_3d[:, 3:6] * (
-                        np.array([.5, 1., .5]) - np.array(bboxes_3d.origin))
-                    bboxes_3d.origin = [.5, 1., .5]
 
                 if pred.bboxes_2d is None:
                     bboxes_2d = self.get_camera_box2d(bboxes_3d, calibs[2])


### PR DESCRIPTION
To compute kitti eval result, the 3d boxes on the lidar coordinate need to be transformed to the one on the kitti camera coodinate. On the kitti camera coordinate, the box origin should be [0.5, 1., 0.5].

If a predicted lidar 3d box origin is [0.5, 0.5, 0.5], its origin should be translate to [0.5, 0.5, 0] before the rotation to kitti camera coordinate. We wrongly translates the origin to [0.5, 1., 0.5] after the rotation to kitti camera coordinate, which causes Car@AP_R40(moderate) drop 1.36% and Car@AP_R11(moderate) drop 4.48% for pv_rcnn . So now we adopt the right implementation.