### PR TITLE
[Bug Fix] Fix centerpoint training bug

### DIFF
--- a/paddle3d/models/optimizers/optimizers.py
+++ b/paddle3d/models/optimizers/optimizers.py
@@ -46,7 +46,7 @@ class OneCycleAdam(object):
             name=name,
             lazy_mode=lazy_mode)
         self.weight_decay = weight_decay
-        self.learning_rate = learning_rate
+        self._learning_rate = learning_rate
         self.beta1 = beta1
 
     def _set_beta1(self, beta1, pow):
@@ -61,14 +61,14 @@ class OneCycleAdam(object):
 
     def before_run(self, max_iters):
         """before_run"""
-        if self.learning_rate is not None:
-            self.learning_rate.before_run(max_iters)
+        if self._learning_rate is not None:
+            self._learning_rate.before_run(max_iters)
         if self.beta1 is not None:
             self.beta1.before_run(max_iters)
 
     def before_iter(self, curr_iter):
         """before_iter"""
-        lr = self.learning_rate.get_lr(curr_iter=curr_iter)
+        lr = self._learning_rate.get_lr(curr_iter=curr_iter)
         self.optimizer.set_lr(lr)
         beta1 = self.beta1.get_momentum(curr_iter=curr_iter)
         self._set_beta1(beta1, pow=curr_iter + 1)


### PR DESCRIPTION
[PR128](https://github.com/PaddlePaddle/Paddle3D/pull/128) introduces a bug that will cause errors during centerpoint training

```python
2022-12-06 03:33:43,665 -     INFO - Finish CenterHead Initialization
Traceback (most recent call last):
  File "tools/train.py", line 189, in <module>
    main(args)
  File "tools/train.py", line 183, in main
    trainer = Trainer(**dic)
  File "/ssd8/wuzewu/code/Paddle3D/paddle3d/apis/trainer.py", line 170, in __init__
    set_lr_scheduler_iters_per_epoch(optimizer._learning_rate,
AttributeError: 'OneCycleAdam' object has no attribute '_learning_rate'
```