### PR TITLE
Update RemoveCameraInvisiblePointsKITTI

### DIFF
--- a/paddle3d/transforms/reader.py
+++ b/paddle3d/transforms/reader.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from pathlib import Path
 from typing import List, Union
 
@@ -123,12 +124,11 @@ class LoadPointCloud(TransformABC):
             data_sweep_list = [
                 data,
             ]
-            for i in np.random.choice(len(sample.sweeps),
-                                      len(sample.sweeps),
-                                      replace=False):
+            for i in np.random.choice(
+                    len(sample.sweeps), len(sample.sweeps), replace=False):
                 sweep = sample.sweeps[i]
-                sweep_data = np.fromfile(sweep.path,
-                                         np.float32).reshape(-1, self.dim)
+                sweep_data = np.fromfile(sweep.path, np.float32).reshape(
+                    -1, self.dim)
                 if self.use_dim:
                     sweep_data = sweep_data[:, self.use_dim]
                 sweep_data = sweep_data.T
@@ -169,11 +169,16 @@ class RemoveCameraInvisiblePointsKITTI(TransformABC):
         calibs = sample.calibs
         C, Rinv, T = kitti_utils.projection_matrix_decomposition(calibs[2])
 
-        im_path = (Path(sample.path).parents[1] / "image_2" /
-                   Path(sample.path).stem).with_suffix(".png")
-        im_shape = np.array(cv2.imread(str(im_path)).shape[:2], dtype=np.int32)
-        im_bbox = [0, 0, im_shape[1], im_shape[0]]
+        im_path = (Path(sample.path).parents[1] / "image_2" / Path(
+            sample.path).stem).with_suffix(".png")
 
+        if os.path.exists(im_path):
+            im_shape = cv2.imread(str(im_path)).shape[:2]
+        else:
+            im_shape = (375, 1242)
+        im_shape = np.array(im_shape, dtype=np.int32)
+
+        im_bbox = [0, 0, im_shape[1], im_shape[0]]
         frustum = F.get_frustum(im_bbox, C)
         frustum = (Rinv @ (frustum - T).T).T
         frustum = kitti_utils.coord_camera_to_velodyne(frustum, calibs)
@@ -203,9 +208,14 @@ class RemoveCameraInvisiblePointsKITTIV2(TransformABC):
         self.V2C = calibs[5]
         self.P2 = calibs[2]
 
-        im_path = (Path(sample.path).parents[1] / "image_2" /
-                   Path(sample.path).stem).with_suffix(".png")
-        img_shape = np.array(cv2.imread(str(im_path)).shape[:2], dtype=np.int32)
+        im_path = (Path(sample.path).parents[1] / "image_2" / Path(
+            sample.path).stem).with_suffix(".png")
+
+        if os.path.exists(im_path):
+            im_shape = cv2.imread(str(im_path)).shape[:2]
+        else:
+            im_shape = (375, 1242)
+        im_shape = np.array(im_shape, dtype=np.int32)
 
         pts = sample.data[:, 0:3]
         # lidar to rect
@@ -215,9 +225,9 @@ class RemoveCameraInvisiblePointsKITTIV2(TransformABC):
         # rect to img
         pts_img, pts_rect_depth = self.rect_to_img(pts_rect)
         val_flag_1 = np.logical_and(pts_img[:, 0] >= 0,
-                                    pts_img[:, 0] < img_shape[1])
+                                    pts_img[:, 0] < im_shape[1])
         val_flag_2 = np.logical_and(pts_img[:, 1] >= 0,
-                                    pts_img[:, 1] < img_shape[0])
+                                    pts_img[:, 1] < im_shape[0])
         val_flag_merge = np.logical_and(val_flag_1, val_flag_2)
         pts_valid_flag = np.logical_and(val_flag_merge, pts_rect_depth >= 0)
 
@@ -282,8 +292,8 @@ class LoadSemanticKITTIRange(TransformABC):
 
         # get projections in image coords
         proj_x = 0.5 * (yaw / np.pi + 1.0)  # in [0.0, 1.0]
-        proj_y = 1.0 - (pitch +
-                        abs(self.lower_inclination)) / self.fov  # in [0.0, 1.0]
+        proj_y = 1.0 - (
+            pitch + abs(self.lower_inclination)) / self.fov  # in [0.0, 1.0]
 
         # scale to image size using angular resolution
         proj_x *= self.proj_W  # in [0.0, W]
@@ -348,8 +358,8 @@ class LoadSemanticKITTIRange(TransformABC):
 
         if sample.labels is not None:
             # load labels
-            raw_label = np.fromfile(sample.labels, dtype=np.uint32).reshape(
-                (-1))
+            raw_label = np.fromfile(
+                sample.labels, dtype=np.uint32).reshape((-1))
             # only fill in attribute if the right size
             if raw_label.shape[0] == points.shape[0]:
                 sem_label = raw_label & 0xFFFF  # semantic label in lower half
@@ -475,11 +485,10 @@ class LoadMultiViewImageFromFiles(TransformABC):
         sample['scale_factor'] = 1.0
         num_channels = 1 if len(img.shape) < 3 else img.shape[2]
 
-        sample['img_norm_cfg'] = dict(mean=np.zeros(num_channels,
-                                                    dtype=np.float32),
-                                      std=np.ones(num_channels,
-                                                  dtype=np.float32),
-                                      to_rgb=False)
+        sample['img_norm_cfg'] = dict(
+            mean=np.zeros(num_channels, dtype=np.float32),
+            std=np.ones(num_channels, dtype=np.float32),
+            to_rgb=False)
         return sample
 
 
@@ -490,12 +499,12 @@ class LoadAnnotations3D(TransformABC):
     """
 
     def __init__(
-        self,
-        with_bbox_3d=True,
-        with_label_3d=True,
-        with_attr_label=False,
-        with_mask_3d=False,
-        with_seg_3d=False,
+            self,
+            with_bbox_3d=True,
+            with_label_3d=True,
+            with_attr_label=False,
+            with_mask_3d=False,
+            with_seg_3d=False,
     ):
         self.with_bbox_3d = with_bbox_3d
         self.with_label_3d = with_label_3d
@@ -550,19 +559,19 @@ class LoadMultiViewImageFromMultiSweepsFiles(object):
     """
 
     def __init__(
-        self,
-        sweeps_num=5,
-        to_float32=False,
-        pad_empty_sweeps=False,
-        sweep_range=[3, 27],
-        sweeps_id=None,
-        imread_flag=-1,  #'unchanged'
-        sensors=[
-            'CAM_FRONT', 'CAM_FRONT_RIGHT', 'CAM_FRONT_LEFT', 'CAM_BACK',
-            'CAM_BACK_LEFT', 'CAM_BACK_RIGHT'
-        ],
-        test_mode=True,
-        prob=1.0,
+            self,
+            sweeps_num=5,
+            to_float32=False,
+            pad_empty_sweeps=False,
+            sweep_range=[3, 27],
+            sweeps_id=None,
+            imread_flag=-1,  #'unchanged'
+            sensors=[
+                'CAM_FRONT', 'CAM_FRONT_RIGHT', 'CAM_FRONT_LEFT', 'CAM_BACK',
+                'CAM_BACK_LEFT', 'CAM_BACK_RIGHT'
+            ],
+            test_mode=True,
+            prob=1.0,
     ):
 
         self.sweeps_num = sweeps_num
@@ -594,17 +603,17 @@ class LoadMultiViewImageFromMultiSweepsFiles(object):
         if self.pad_empty_sweeps and len(sample['sweeps']) == 0:
             for i in range(self.sweeps_num):
                 sweep_imgs_list.extend(imgs)
-                mean_time = (self.sweep_range[0] +
-                             self.sweep_range[1]) / 2.0 * 0.083
+                mean_time = (
+                    self.sweep_range[0] + self.sweep_range[1]) / 2.0 * 0.083
                 timestamp_imgs_list.extend(
                     [time + mean_time for time in img_timestamp])
                 for j in range(nums):
                     sample['filename'].append(sample['filename'][j])
                     sample['lidar2img'].append(np.copy(sample['lidar2img'][j]))
-                    sample['intrinsics'].append(np.copy(
-                        sample['intrinsics'][j]))
-                    sample['extrinsics'].append(np.copy(
-                        sample['extrinsics'][j]))
+                    sample['intrinsics'].append(
+                        np.copy(sample['intrinsics'][j]))
+                    sample['extrinsics'].append(
+                        np.copy(sample['extrinsics'][j]))
         else:
             if self.sweeps_id:
                 choices = self.sweeps_id
@@ -625,9 +634,8 @@ class LoadMultiViewImageFromMultiSweepsFiles(object):
                     else:
                         sweep_range = list(
                             range(self.sweep_range[0], self.sweep_range[1]))
-                    choices = np.random.choice(sweep_range,
-                                               self.sweeps_num,
-                                               replace=False)
+                    choices = np.random.choice(
+                        sweep_range, self.sweeps_num, replace=False)
                 else:
                     choices = [
                         int((self.sweep_range[0] + self.sweep_range[1]) / 2) - 1


### PR DESCRIPTION
* Optimize the implementation of RemoveCameraInvisiblePointsKITTI and RemoveCameraInvisiblePointsKITTIV2, when the camera data of KITTI does not exist locally, use the default shape configuration. This allows users to train lidar-based models without downloading the KITTI camera dataset