### PR TITLE
[Bug Fix] Uniform init bn weight for pvrcnn and voxelrcnn

### DIFF
--- a/paddle3d/models/detection/pv_rcnn/pv_rcnn.py
+++ b/paddle3d/models/detection/pv_rcnn/pv_rcnn.py
@@ -27,6 +27,7 @@ from paddle3d.geometries import BBoxes3D
 from paddle3d.models.common.model_nms_utils import class_agnostic_nms
 from paddle3d.sample import Sample, SampleMeta
 from paddle3d.utils.logger import logger
+from paddle3d.models.layers.param_init import uniform_init
 
 
 @manager.MODELS.add_component
@@ -46,6 +47,19 @@ class PVRCNN(nn.Layer):
         self.point_head = point_head
         self.roi_head = roi_head
         self.post_process_cfg = post_process_cfg
+        self.init_weights()
+
+    def init_weights(self):
+        need_uniform_init_bn_weight_modules = [
+            self.middle_encoder, self.point_encoder.vsa_point_feature_fusion,
+            self.backbone, self.neck, self.point_head,
+            self.roi_head.shared_fc_layer, self.roi_head.cls_layers,
+            self.roi_head.reg_layers
+        ]
+        for module in need_uniform_init_bn_weight_modules:
+            for layer in module.sublayers():
+                if 'BatchNorm' in layer.__class__.__name__:
+                    uniform_init(layer.weight, 0, 1)
 
     def voxelize(self, points):
         voxels, coordinates, num_points_in_voxel = self.voxelizer(points)

--- a/paddle3d/models/heads/roi_heads/voxelrcnn_head.py
+++ b/paddle3d/models/heads/roi_heads/voxelrcnn_head.py
@@ -139,7 +139,7 @@ class VoxelRCNNHead(RoIHeadBase):
         constant_init(self.cls_pred_layer.bias, value=0)
         self.reg_pred_layer.weight.set_value(
             paddle.normal(
-                mean=0, std=0.01, shape=self.reg_pred_layer.weight.shape))
+                mean=0, std=0.001, shape=self.reg_pred_layer.weight.shape))
         constant_init(self.reg_pred_layer.bias, value=0)
 
     def roi_grid_pool(self, batch_dict):


### PR DESCRIPTION
 Default initialize method for batchnorm layer weights in PVRCNN and VoxelRCNN should be uniform, otherwise, the car AP@R11 may drop ~4% randomly.