### PR TITLE
Fix slim

### DIFF
--- a/paddle3d/slim/quant.py
+++ b/paddle3d/slim/quant.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddleslim
-
 from paddle3d.utils.logger import logger
 
 
@@ -27,6 +25,8 @@ class QAT:
             logger.info("model before quant")
             logger.info(model)
 
+        # lazy import
+        import paddleslim
         self.quanter = paddleslim.QAT(config=self.quant_config)
         self.quanter.quantize(model)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ opencv-python
 pandas
 paddledet
 paddleseg
-paddleslim
 pyquaternion
 pyyaml
 pillow<=8.3.2


### PR DESCRIPTION
The import of paddleslim will cause the following problems:
1. A lot of logs are printed when using numba.cuda
2. The settings of matplotlib conflict with nuscenes

Considering that slim is not the main feature of Paddle3D, the paddleslim is lazy-loaded