### PR TITLE
[Docs] add centerpoint trt python deploy explanation in docs

### DIFF
--- a/docs/models/centerpoint/README.md
+++ b/docs/models/centerpoint/README.md
@@ -360,6 +360,8 @@ sh compile.sh
 python infer.py --model_file /path/to/centerpoint.pdmodel --params_file /path/to/centerpoint.pdiparams --lidar_file /path/to/lidar.pcd.bin --num_point_dim 5
 ```
 
+Python开启TensorRT的推理步骤与C++开启TensorRT加速推理一致，请参考文档前面介绍【开启TensorRT加速预测】并将C++命令参数替换成Python的命令参数。推荐使用PaddlePaddle 的官方镜像，镜像内已经预安装TensorRT。官方镜像请至[Paddle官网](https://www.paddlepaddle.org.cn/install/quick?docurl=/documentation/docs/zh/install/docker/linux-docker.html)进行下载。
+
 ## <h2 id="9">自定义数据集</h2>
 
 请参考文档[自定义数据集格式说明](../../../datasets/custom.md)准备自定义数据集。


### PR DESCRIPTION
Add centerpoint trt python deploy explanation in docs, see issue https://github.com/PaddlePaddle/Paddle3D/issues/183