### PR TITLE
[WIP][Bug fix] use pad_shape instead of img_shape for bevformer and recover the origin code where the first frame pre_bev is None

### DIFF
--- a/paddle3d/models/detection/bevformer/bevformer.py
+++ b/paddle3d/models/detection/bevformer/bevformer.py
@@ -124,12 +124,6 @@ class BEVFormer(nn.Layer):
                 img_metas = [each[i] for each in img_metas_list]
                 if not img_metas[0]['prev_bev_exists']:
                     prev_bev = None
-                if prev_bev is None:
-                    prev_bev = paddle.zeros([
-                        self.pts_bbox_head.bev_w * self.pts_bbox_head.bev_w, bs,
-                        self.pts_bbox_head.transformer.embed_dims
-                    ],
-                                            dtype='float32')
                 img_feats = [each_scale[:, i] for each_scale in img_feats_list]
                 prev_bev = self.pts_bbox_head(
                     img_feats, img_metas, prev_bev, only_bev=True)
@@ -177,12 +171,6 @@ class BEVFormer(nn.Layer):
         img_metas = [each[len_queue - 1] for each in img_metas]
         if not img_metas[0]['prev_bev_exists']:
             prev_bev = None
-        if prev_bev is None:
-            prev_bev = paddle.zeros([
-                self.pts_bbox_head.bev_w * self.pts_bbox_head.bev_w, bs,
-                self.pts_bbox_head.transformer.embed_dims
-            ],
-                                    dtype='float32')
 
         img_feats = self.extract_feat(img=img, img_metas=img_metas)
 
@@ -220,13 +208,6 @@ class BEVFormer(nn.Layer):
         else:
             img_metas[0]['can_bus'][-1] = 0
             img_metas[0]['can_bus'][:3] = 0
-
-        if self.prev_frame_info['prev_bev'] is None:
-            self.prev_frame_info['prev_bev'] = paddle.zeros([
-                self.pts_bbox_head.bev_w * self.pts_bbox_head.bev_w,
-                img.shape[0], self.pts_bbox_head.transformer.embed_dims
-            ],
-                                                            dtype='float32')
 
         new_prev_bev, bbox_results = self.simple_test(
             img_metas, img, prev_bev=self.prev_frame_info['prev_bev'], **kwargs)
@@ -318,9 +299,9 @@ class BEVFormer(nn.Layer):
             "lidar2img":
             paddle.static.InputSpec(
                 shape=[-1, -1, 4, 4], dtype="float32", name='lidar2img'),
-            "img_shape":
+            "pad_shape":
             paddle.static.InputSpec(
-                shape=[6, 3], dtype="int32", name='img_shape'),
+                shape=[6, 3], dtype="int32", name='pad_shape'),
         }
 
         input_spec = [image_spec, pre_bev_spec, img_metas_spec]

--- a/paddle3d/models/detection/bevformer/bevformer_head.py
+++ b/paddle3d/models/detection/bevformer/bevformer_head.py
@@ -263,7 +263,6 @@ class BEVFormerHead(nn.Layer):
                 img_metas=img_metas,
                 prev_bev=prev_bev,
             )
-            bev_embed = bev_embed.transpose([1, 0, 2])
             return bev_embed
         else:
             outputs = self.transformer(

--- a/paddle3d/models/transformers/transformer.py
+++ b/paddle3d/models/transformers/transformer.py
@@ -166,25 +166,17 @@ class PerceptionTransformer(nn.Layer):
             [each['can_bus'][0] for each in kwargs['img_metas']])
         delta_y = paddle.concat(
             [each['can_bus'][1] for each in kwargs['img_metas']])
-        #np.save('delta_x.npy', delta_x.numpy())
-        #np.save('delta_y.npy', delta_y.numpy())
         ego_angle = paddle.concat(
             [each['can_bus'][-2] / pi_tensor for each in kwargs['img_metas']])
-        #np.save('ego_angle.npy', ego_angle)
         grid_length_y = grid_length[0]
         grid_length_x = grid_length[1]
         translation_length = paddle.sqrt(delta_x**2 + delta_y**2)
-        #np.save('translation_length.npy', translation_length.numpy())
         translation_angle = paddle.atan2(delta_y, delta_x) / pi_tensor
-        # translation_angle = paddle.angle(delta_y, delta_x) / pi_tensor
-        #np.save('translation_angle.npy', translation_angle.numpy())
         bev_angle = ego_angle - translation_angle
         shift_y = translation_length * \
             paddle.cos(bev_angle * pi_tensor) / grid_length_y / bev_h
         shift_x = translation_length * \
             paddle.sin(bev_angle * pi_tensor) / grid_length_x / bev_w
-        #np.save('shift_x.npy', shift_x.numpy())
-        #np.save('shift_y.npy', shift_y.numpy())
 
         shift_y = shift_y * self.use_shift
         shift_x = shift_x * self.use_shift
@@ -193,39 +185,19 @@ class PerceptionTransformer(nn.Layer):
                               shift_y]).transpose([1, 0])  # xy, bs -> bs, xy
 
         shift = shift.cast(bev_queries.dtype)
-        '''
         if prev_bev is not None:
             if prev_bev.shape[1] == bev_h * bev_w:
                 prev_bev = prev_bev.transpose([1, 0, 2])
             if self.rotate_prev_bev:
                 for i in range(bs):
                     rotation_angle = kwargs['img_metas'][i]['can_bus'][-1]
-                    tmp_prev_bev = prev_bev[:, i].reshape([
-                        bev_h, bev_w, -1]).transpose([2, 0, 1])
-                    tmp_prev_bev = rotate(tmp_prev_bev, rotation_angle,
-                                          center=self.rotate_center)
-                    # #np.save('tmp_prev_bev.npy', tmp_prev_bev.numpy())
-                    tmp_prev_bev = tmp_prev_bev.transpose([1, 2, 0]).reshape([
-                        bev_h * bev_w, 1, -1])
-                    prev_bev[:, i] = tmp_prev_bev[:, 0]
-        '''
-        if prev_bev is not None:
-            if self.rotate_prev_bev:
-                for i in range(bs):
-                    valid_prev_bev = prev_bev[:, i].cast('bool').any().cast(
-                        'int32')
-                    rotation_angle = kwargs['img_metas'][i]['can_bus'][-1]
                     tmp_prev_bev = prev_bev[:, i].reshape(
                         [bev_h, bev_w, -1]).transpose([2, 0, 1])
                     tmp_prev_bev = rotate(
                         tmp_prev_bev, rotation_angle, center=self.rotate_center)
-                    # #np.save('tmp_prev_bev.npy', tmp_prev_bev.numpy())
                     tmp_prev_bev = tmp_prev_bev.transpose([1, 2, 0]).reshape(
                         [bev_h * bev_w, 1, -1])
-                    prev_bev[:,
-                             i] = tmp_prev_bev[:,
-                                               0] * valid_prev_bev + prev_bev[:, i] * (
-                                                   1 - valid_prev_bev)
+                    prev_bev[:, i] = tmp_prev_bev[:, 0]
 
         # add can bus signals
         # can_bus = paddle.to_tensor(
@@ -258,13 +230,6 @@ class PerceptionTransformer(nn.Layer):
         feat_flatten = feat_flatten.transpose(
             [0, 2, 1, 3])  # (num_cam, H*W, bs, embed_dims)
 
-        # #np.save('bev_queries.npy', bev_queries.numpy())
-        # #np.save('feat_flatten.npy', feat_flatten.numpy())
-        # #np.save('bev_pos.npy', bev_pos.numpy())
-        # #np.save('prev_bev.npy', prev_bev.numpy())
-        # #np.save('spatial_shapes.npy', spatial_shapes.numpy())
-        # #np.save('level_start_index.npy', level_start_index.numpy())
-        # #np.save('shift.npy', shift.numpy())
         bev_embed = self.encoder(
             bev_queries,
             feat_flatten,
@@ -277,8 +242,6 @@ class PerceptionTransformer(nn.Layer):
             prev_bev=prev_bev,
             shift=shift,
             **kwargs)
-        # #np.save('bev_embed.npy', bev_embed.numpy())
-        # exit()
         return bev_embed
 
     def forward(self,


### PR DESCRIPTION
- Use `pad_shape` instead of `img_shape` for bevformer, where `img_shape` reserves the origin image shape and `pad_shape` is the image shape after padded.

- Recover the origin codes where the first frame `pre_bev` is None. Present codes set the first frame `pre_bev `to zeros  during the trainng phase  in order to keep consistent with the deploy phase, but  it seems to be not too right. The reasons are two below:
1. Temporal information cannot be closed flexiblely where the `pre_bev` should be set as None.
2. When temporal information is needed, `pre_bev` is the key and value of the temporal encoder layers. If `pre_bev` is None, the encoder layer will set  the value of `pre_bev` the same as query.