### PR TITLE
[Feature] Support config override with argparse

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -58,6 +58,8 @@ def parse_args():
         type=int,
         default=None)
     parser.add_argument(
+        '--opts', help='override config options.', default=None, nargs='+')
+    parser.add_argument(
         '--keep_checkpoint_max',
         dest='keep_checkpoint_max',
         help='Maximum number of checkpoints to save',
@@ -154,7 +156,8 @@ def main(args):
         learning_rate=args.learning_rate,
         batch_size=args.batch_size,
         iters=args.iters,
-        epochs=args.epochs)
+        epochs=args.epochs,
+        opts=args.opts)
 
     if cfg.train_dataset is None:
         raise RuntimeError(


### PR DESCRIPTION
support config override with argparse, use `--opts k1 v1 k2 v2` to override.
```python
# override milstones with [300,500]
python tools/train.py --config xxx/xxx.yaml --opts lr_scheduler.milestones [300,500]
```