### PR TITLE
[Bug fix] operate logical NOT on attn_mask for multiheadattention of bevformer

### DIFF
--- a/paddle3d/models/transformers/attentions/multihead_attention.py
+++ b/paddle3d/models/transformers/attentions/multihead_attention.py
@@ -173,6 +173,8 @@ class MultiheadAttention(nn.Layer):
             value = value.transpose([1, 0, 2])
 
         if key_padding_mask is None:
+            if attn_mask is not None:
+                attn_mask = ~attn_mask
             out = self.attn(
                 query=query, key=key, value=value, attn_mask=attn_mask)
         else:


### PR DESCRIPTION
The `attn_mask` of `paddle.nn.MultiHeadAttention` is NOT with the one of torch, so we operate logical NOT on `attn_mask` for `MultiheadAttention` of bevformer.