### PR TITLE
[Bug fix] Enlarge workspace size for CenterPoint/PointPillars and decrease min_subgraph_size for CenterPoint

### DIFF
--- a/deploy/centerpoint/python/infer.py
+++ b/deploy/centerpoint/python/infer.py
@@ -121,9 +121,9 @@ def init_predictor(model_file,
         elif trt_precision == 2:
             precision_mode = paddle.inference.PrecisionType.Int8
         config.enable_tensorrt_engine(
-            workspace_size=1 << 20,
+            workspace_size=1 << 30,
             max_batch_size=1,
-            min_subgraph_size=30,
+            min_subgraph_size=3,
             precision_mode=precision_mode,
             use_static=trt_use_static,
             use_calib_mode=False)

--- a/deploy/pointpillars/python/infer.py
+++ b/deploy/pointpillars/python/infer.py
@@ -199,7 +199,7 @@ def init_predictor(model_file,
         if trt_precision == 1:
             precision_mode = paddle.inference.PrecisionType.Half
         config.enable_tensorrt_engine(
-            workspace_size=1 << 20,
+            workspace_size=1 << 30,
             max_batch_size=1,
             min_subgraph_size=10,
             precision_mode=precision_mode,


### PR DESCRIPTION
- Decrease `min_subgraph_size` from 30 to 3 for CenterPoint when using Python Paddle Inference TRT, othersize the inference speed is very slow.
- Enlarge `workspace_size` for CenterPoint and pointpillars using Python Paddle Inference TRT, othersize the inference cannot be done in a OrinX device.