### PR TITLE
[Bug Fix] reset do_bind default value to False because it will close the terminate unexpectedlly when users break off the training process

### DIFF
--- a/paddle3d/apis/trainer.py
+++ b/paddle3d/apis/trainer.py
@@ -122,7 +122,7 @@ class Trainer:
             scheduler: Union[dict, SchedulerABC] = dict(),
             dataloader_fn: Union[dict, Callable] = dict(),
             amp_cfg: Optional[dict] = None,
-            do_bind: Optional[bool] = True):
+            do_bind: Optional[bool] = False):
 
         self.model = model
         self.optimizer = optimizer


### PR DESCRIPTION
reset do_bind default value to False because it will close the terminate unexpectedlly when users break off the training process