### PR TITLE
【Hackathon No.174】Add NeRF to PaddleRendering

### DIFF
--- a/contrib/PaddleRendering/configs/nerf/blender_data.yml
+++ b/contrib/PaddleRendering/configs/nerf/blender_data.yml
@@ -1,0 +1,98 @@
+iters: 200000
+
+image_batch_size: -1   # sample batch of rays from all images at each iteration
+ray_batch_size: 1024
+image_resampling_interval: -1
+
+train_metrics:
+  - type: PSNRMeter
+
+val_metrics:
+  - type: PSNRMeter
+  - type: SSIMMeter
+
+train_dataset:
+  type: BlenderDataset
+  dataset_root: data/nerf_synthetic/lego
+  camera_scale_factor: 1.0
+  background_color: white
+  transforms:
+    - type: LoadImage
+    - type: Normalize
+    - type: AlphaBlending
+  split: train
+
+val_dataset:
+  type: BlenderDataset
+  dataset_root: data/nerf_synthetic/lego
+  camera_scale_factor: 1.0
+  background_color: white
+  transforms:
+    - type: LoadImage
+    - type: Normalize
+    - type: AlphaBlending
+  split: val
+
+optimizer:
+  type: Adam
+  beta1: .9
+  beta2: .999
+  epsilon: 1.0e-7
+
+lr_scheduler:
+  type: ExponentialDecay
+  lr_init: 0.0005
+  delay_rate: 0.1
+  delay_steps: 500000
+
+model:
+  type: NeRF
+  coarse_ray_sampler:
+    type: UniformSampler
+    num_samples: 64
+    aabb: [-1.3, -1.3, -1.3, 1.3, 1.3, 1.3]
+  fine_ray_sampler:
+    type: PDFSampler
+    num_samples: 128
+  field:
+    type: NeRFField
+    dir_encoder:
+      type: NeRFEncoder
+      min_freq: 0.
+      max_freq: 3.
+      num_freqs: 4
+      include_identity: True
+    pos_encoder:
+      type: NeRFEncoder
+      min_freq: 0.
+      max_freq: 9.
+      num_freqs: 10
+      include_identity: True
+    stem_net:
+      type: MLP
+      input_dim: 63
+      hidden_dim: 256
+      output_dim: 256
+      num_layers: 8
+      skip_layers: [4]
+      activation: relu
+      output_activation: relu
+    density_head:
+      type: MLP
+      input_dim: 256
+      output_dim: 1
+      num_layers: 1
+    color_head:
+      type: MLP
+      input_dim: 283
+      output_dim: 3
+      hidden_dim: 128
+      num_layers: 2
+      activation: relu
+      output_activation: sigmoid
+    density_bias: -1.0
+    rgb_padding: 0.001
+    use_integrated_encoding: False
+  rgb_renderer:
+    type: RGBRenderer
+    background_color: white

--- a/contrib/PaddleRendering/configs/nerf/blender_data_efficient.yml
+++ b/contrib/PaddleRendering/configs/nerf/blender_data_efficient.yml
@@ -1,0 +1,103 @@
+iters: 200000
+
+image_batch_size: -1   # sample batch of rays from all images at each iteration
+ray_batch_size: 1024
+image_resampling_interval: -1
+
+train_metrics:
+  - type: PSNRMeter
+
+val_metrics:
+  - type: PSNRMeter
+  - type: SSIMMeter
+
+train_dataset:
+  type: BlenderDataset
+  dataset_root: data/nerf_synthetic/lego
+  camera_scale_factor: 1.0
+  background_color: white
+  transforms:
+    - type: LoadImage
+    - type: Normalize
+    - type: AlphaBlending
+  split: train
+
+val_dataset:
+  type: BlenderDataset
+  dataset_root: data/nerf_synthetic/lego
+  camera_scale_factor: 1.0
+  background_color: white
+  transforms:
+    - type: LoadImage
+    - type: Normalize
+    - type: AlphaBlending
+  split: val
+
+optimizer:
+  type: Adam
+  beta1: .9
+  beta2: .999
+  epsilon: 1.0e-7
+
+lr_scheduler:
+  type: ExponentialDecay
+  lr_init: 0.0005
+  delay_rate: 0.1
+  delay_steps: 500000
+
+model:
+  type: NeRF
+  coarse_ray_sampler:
+    type: VolumetricSampler
+    occupancy_grid:
+      type: OccupancyGrid
+      resolution: 64
+      contraction_type: 0
+      aabb: [ -1.3, -1.3, -1.3, 1.3, 1.3, 1.3 ]
+    grid_update_interval: 16
+    step_size: .005
+  fine_ray_sampler:
+    type: EfficientPDFSampler
+    num_samples: 128
+  field:
+    type: NeRFField
+    dir_encoder:
+      type: NeRFEncoder
+      min_freq: 0.
+      max_freq: 3.
+      num_freqs: 4
+      include_identity: True
+    pos_encoder:
+      type: NeRFEncoder
+      min_freq: 0.
+      max_freq: 9.
+      num_freqs: 10
+      include_identity: True
+    stem_net:
+      type: MLP
+      input_dim: 63
+      hidden_dim: 256
+      output_dim: 256
+      num_layers: 8
+      skip_layers: [4]
+      activation: relu
+      output_activation: relu
+    density_head:
+      type: MLP
+      input_dim: 256
+      output_dim: 1
+      num_layers: 1
+    color_head:
+      type: MLP
+      input_dim: 283
+      output_dim: 3
+      hidden_dim: 128
+      num_layers: 2
+      activation: relu
+      output_activation: sigmoid
+    density_bias: -1.0
+    rgb_padding: 0.001
+    use_integrated_encoding: False
+  rgb_renderer:
+    type: RGBRenderer
+    background_color: white

--- a/contrib/PaddleRendering/docs/models/nerf/README.md
+++ b/contrib/PaddleRendering/docs/models/nerf/README.md
@@ -1,0 +1,113 @@
+# NeRF: Scenes as Neural Radiance Fields for View Synthesis
+
+## 目录
+
+* [引用](#1)
+* [简介](#2)
+* [模型库](#3)
+* [训练配置](#4)
+* [使用教程](#5)
+    * [数据准备](#51)
+    * [训练](#52)
+    * [评估](#53)
+
+## <h2 id="1">引用</h2>
+
+```bibtex
+@inproceedings{mildenhall2020nerf,
+  title={NeRF: Representing Scenes as Neural Radiance Fields for View Synthesis},
+  author={Ben Mildenhall and Pratul P. Srinivasan and Matthew Tancik and Jonathan T. Barron and Ravi Ramamoorthi and Ren Ng},
+  year={2020},
+  booktitle={ECCV},
+}
+```
+
+## <h2 id="2">简介</h2>
+
+NeRF
+
+神经辐射场 (Neural Radiance Field, NERF)是发表在ECCV 2020上的谷歌和伯克利大学的研究，只需要少量的静态图像，就能通过[NeRF]([http://www.matthewtancik.com/nerf])生成多视角的逼真3D效果。其可以简要概括为用一个MLP神经网络去隐式地学习一个静态3D场景。为了训练网络，针对一个静态场景，需要提供大量相机参数已知的图片。使用基于这些图片训练好的神经网络，就可以从任意角度渲染出图片结果。
+
+
+## <h2 id="3">模型库</h2>
+
+- NeRF 在 Blender Dataset 数据集上的表现
+
+|  场景  |  PSNR   |  SSIM  |                                                 模型下载                                                 |                          配置文件                           |
+|:----:|:-------:|:------:|:----------------------------------------------------------------------------------------------------:|:-------------------------------------------------------:|
+| lego | 32.581 | 0.9599 | [model]() | [config](../../../configs/nerf/blender_data.yml) |
+| lego | 34.409 | 0.9703 | [model]() | [efficient_config](../../../configs/nerf/blender_data_efficient.yml) |
+
+## <h2 id="4">训练配置</h2>
+
+我们提供了在开源数据集上的训练配置与结果，详见 [NeRF训练配置](../../../configs/nerf)。其中 `blender_data_efficient.yml` 使用了[Instant-ngp](https://arxiv.org/abs/2201.05989)中提出的光线采样策略，相较于原生版本训练速度提升约3倍。
+
+## <h2 id="5">使用教程</h2>
+
+### <h3 id="51">数据准备</h3>
+
+数据文件软链至`PaddleRender/data/`目录下，或在 [配置文件](../../../configs/nerf) 中指定数据集路径。
+
+### <h3 id="52">训练</h3>
+
+位于`PaddleRendering/`目录下，执行：
+
+```bash
+export PYTHONPATH='.'
+
+# 单卡训练
+python tools/train.py \
+  --config configs/nerf/blender_data.yml \
+  --save_dir nerf_blender \
+  --log_interval 1000 \
+  --save_interval 10000
+
+# 多卡训练 (使用0,1号GPU为例)
+python -m paddle.distributed.launch --devices 0,1 \
+    tools/train.py \
+    --config configs/nerf/blender_data.yml \
+    --save_dir nerf_blender \
+    --log_interval 1000 \
+    --save_interval 10000
+```
+
+训练脚本支持设置如下参数：
+
+| 参数名                         | 用途                                                                                                                                       | 是否必选项 | 默认值        |
+|:----------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------|:------|:-----------|
+| config                      | 配置文件                                                                                                                                     | 是     | -          |
+| image_batch_size            | 图片 mini-batch 大小，每次迭代从该参数指定数量的图片中采样光线。如果为`-1`，每次迭代从整个数据集的图片中采样光线                                                                         | 否     | -1         |
+| ray_batch_size              | 光线 mini-batch 大小，每次迭代从图片 batch 中采样光线的数量                                                                                                  | 否     | 1          |
+| image_resampling_interval   | 为提升训练性能，我们使用了图片预加载策略（将图片 mini-batch 预加载到GPU上缓存，每次迭代从缓存的图片中采样光线），该参数用于指定对GPU上图片缓存进行更新的间隔。如果为`-1`，图片缓存不会被更新（适用于`image_batch_size`为`-1`的情况） | 否     | -1         |
+| use_adaptive_ray_batch_size | 是否采用自动调整光线 mini-batch 大小的训练策略。如果开启，将确保模型每次迭代处理的有效样本数稳定在`2^18`，有助于提升模型收敛效率，缩短训练时间                                                         | 否     | 否          |
+| iters                       | 训练迭代数                                                                                                                                    | 否     | 在训练配置文件中指定 |
+| learning_rate               | 学习率                                                                                                                                      | 否     | 在训练配置文件中指定 |
+| save_dir                    | 模型和visualdl日志文件的保存根路径                                                                                                                    | 否     | output     |
+| save_interval               | 模型保存的iteration间隔数                                                                                                                        | 否     | 1000       |
+| do_eval                     | 是否在保存模型时进行评估                                                                                                                             | 否     | 否          |
+| resume                      | 是否恢复中断的训练                                                                                                                                | 否     | 否          |
+| model                       | 预训练模型路径（`.pdparams`文件）                                                                                                                   | 否     | 不使用预训练模型   |
+| log_interval                | 打印日志的间隔步数                                                                                                                                | 否     | 500        |
+| keep_checkpoint_max         | 模型保存个数（当保存模型次数超过该限制时，最旧的模型会被自动删除）                                                                                                        | 否     | 5          |
+
+### <h3 id="53">评估</h3>
+
+位于`PaddleRendering/`目录下，执行：
+
+```shell
+export PYTHONPATH='.'
+python tools/evaluate.py \
+  --config configs/nerf/blender_data.yml \
+  --model nerf_blender/iter_200000/model.pdparams
+```
+
+评估完成后会在`--model`对应的目录下保存渲染结果图片。
+
+评估脚本支持设置如下参数：
+
+| 参数名            | 用途                             | 是否必选项 | 默认值   |
+|:---------------|:-------------------------------|:------|:------|
+| config         | 配置文件                           | 是     | -     |
+| model          | 待评估模型路径                        | 是     | -     |
+| ray_batch_size | 光线 mini-batch 大小               | 否     | 16384 |
+| num_workers    | 用于异步读取数据的进程数量， 大于等于1时开启子进程读取数据 | 否     | 0     |

--- a/contrib/PaddleRendering/docs/models/nerf/README_EN.md
+++ b/contrib/PaddleRendering/docs/models/nerf/README_EN.md
@@ -1,0 +1,114 @@
+# NeRF: Scenes as Neural Radiance Fields for View Synthesis
+
+## Contents
+
+* [Reference](#1)
+* [Introduction](#2)
+* [Model Zoo](#3)
+* [Training Configuration](#4)
+* [Tutorials](#5)
+    * [Data Preparation](#51)
+    * [Training](#52)
+    * [Evaluation](#53)
+
+## <h2 id="1">Reference</h2>
+
+```bibtex
+@inproceedings{mildenhall2020nerf,
+  title={NeRF: Representing Scenes as Neural Radiance Fields for View Synthesis},
+  author={Ben Mildenhall and Pratul P. Srinivasan and Matthew Tancik and Jonathan T. Barron and Ravi Ramamoorthi and Ren Ng},
+  year={2020},
+  booktitle={ECCV},
+}
+```
+
+## <h2 id="2">Introduction</h2>
+
+NeRF
+
+A neural radiance field is a simple fully connected network (weights are ~5MB) trained to reproduce input views of a single scene using a rendering loss. The network directly maps from spatial location and viewing direction (5D input) to color and opacity (4D output), acting as the "volume" so we can use volume rendering to differentiably render new views.
+
+## <h2 id="3">Model Zoo</h2>
+
+- Benchmarks on Blender Dataset.
+
+| Scene |  PSNR   |  SSIM  |                                               Download                                               |                      Configuration                      |
+|:-----:|:-------:|:------:|:----------------------------------------------------------------------------------------------------:|:-------------------------------------------------------:|
+| lego | 32.581 | 0.9599 | [model]() | [config](../../../configs/nerf/blender_data.yml) |
+| lego | 34.409 | 0.9703 | [model]() | [efficient_config](../../../configs/nerf/blender_data_efficient.yml) |
+
+## <h2 id="4">Training Configuration</h2>
+
+For training configuration on open source datasets, refer
+to [NeRF Training Configuration](../../../configs/nerf). Among them, `blender_data_efficient.yml` uses the ray sampling strategy proposed in [Instant-ngp](https://arxiv.org/abs/2201.05989), which speedups the training process by almost 3 times.
+
+## <h2 id="5">Tutorials</h2>
+
+### <h3 id="51">Data Preparation</h3>
+
+Soft link the dataset file to `PaddleRender/data/` or specify the dataset path
+in [configuration file](../../../configs/nerf).
+
+### <h3 id="52">Training</h3>
+
+At `PaddleRendering/`, execute:
+
+```shell
+export PYTHONPATH='.'
+
+# Train on single GPU
+python tools/train.py \
+  --config configs/nerf/blender_data.yml \
+  --save_dir nerf_blender \
+  --log_interval 1000 \
+  --save_interval 10000
+
+# Train on multiple GPUs (GPU 0, 1 as an example)
+python -m paddle.distributed.launch --devices 0,1 \
+    tools/train.py \
+    --config configs/nerf/blender_data.yml \
+    --save_dir nerf_blender \
+    --log_interval 1000 \
+    --save_interval 10000
+```
+
+The training script accepts the following arguments and options:
+
+| Arguments & Options         | Explanation                                                                                                                                                                                                                                                                                               | Required | Defaults                         |
+|:----------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------|:---------------------------------|
+| config                      | Configuration file.                                                                                                                                                                                                                                                                                       | YES      | -                                |
+| image_batch_size            | Batch size of images, from which rays are sampled every iteration.<br>If `-1`, rays are sampled from the entire dataset.                                                                                                                                                                                  | NO       | -1                               |
+| ray_batch_size              | Batch size of rays, the number of rays sampled from image mini-batch every iteration.                                                                                                                                                                                                                     | NO       | 1                                |
+| image_resampling_interval   | To accelerate training, each GPU maintains a image buffer (image mini-batch is prefetched, rays are sampled from the buffer every iteration).<br>This argument specifies the interval of updating the image buffer. If `-1`, the buffer is never updated (for the case where `image_batch_size` is `-1`). | NO       | -1                               |
+| use_adaptive_ray_batch_size | Whether to use an adaptive `ray_batch_size`.<br>If enabled, the number of valid samples fed to the model is stable at `2^18`, which accelerates model convergence.                                                                                                                                        | NO       | FALSE                            |
+| iters                       | The number of iterations.                                                                                                                                                                                                                                                                                 | NO       | Specified in configuration file. |
+| learning_rate               | Learning rate.                                                                                                                                                                                                                                                                                            | NO       | Specified in configuration file. |
+| save_dir                    | Directory where models and VisualDL logs are saved.                                                                                                                                                                                                                                                       | NO       | output                           |
+| save_interval               | Interval of saving checkpoints.                                                                                                                                                                                                                                                                           | NO       | 1000                             |
+| do_eval                     | Whether to do evaluation after checkpoints are saved.                                                                                                                                                                                                                                                     | NO       | FALSE                            |
+| resume                      | Whether to resume interrupted training.                                                                                                                                                                                                                                                                   | NO       | FALSE                            |
+| model                       | Path to pretrained model file (`.pdparams`).                                                                                                                                                                                                                                                              | NO       | No pretrained model.             |
+| log_interval                | Interval for logging.                                                                                                                                                                                                                                                                                     | NO       | 500                              |
+| keep_checkpoint_max         | The maximum number of saved checkpoints (When the number of saved checkpoint exceeds the limit, the oldest checkpoint is automatically deleted).                                                                                                                                                          | NO       | 5                                |
+
+### <h3 id="53">Evaluation</h3>
+
+At `PaddleRendering/`, execute:
+
+```shell
+export PYTHONPATH='.'
+python tools/evaluate.py \
+  --config configs/nerf/blender_data.yml \
+  --model nerf_blender/iter_2 00000/model.pdparams
+```
+
+At the end of the evaluation, the rendering results will be saved in the directory specified by `--model`.
+
+The evaluation script accepts the following arguments and options:
+
+| Arguments & Options | Explanation                                                                                        | Required | Defaults |
+|:--------------------|:---------------------------------------------------------------------------------------------------|:---------|:---------|
+| config              | Configuration file.                                                                                | YES      | -        |
+| model               | Model to be evaluated.                                                                             | YES      | -        |
+| ray_batch_size      | Ray batch size.                                                                                    | NO       | 16384    |
+| num_workers         | The number of subprocess to load data, `0` for no subprocess used and loading data in main process | NO       | 0        |

--- a/contrib/PaddleRendering/pprndr/models/nerf/__init__.py
+++ b/contrib/PaddleRendering/pprndr/models/nerf/__init__.py
@@ -12,13 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from .encoders import *
-from .fields import *
-from .instant_ngp import *
-from .layers import *
-from .mip_nerf import *
-from .plenoxels import *
-from .nerf import *
-from .ray_samplers import *
-from .ref_nerf import *
-from .renderers import *
+from .nerf import NeRF

--- a/contrib/PaddleRendering/pprndr/models/nerf/nerf.py
+++ b/contrib/PaddleRendering/pprndr/models/nerf/nerf.py
@@ -1,0 +1,115 @@
+#  Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License")
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Dict, Tuple, Union
+
+import paddle
+import paddle.nn as nn
+
+from pprndr.apis import manager
+from pprndr.cameras.rays import RayBundle
+from pprndr.models.fields import BaseField
+from pprndr.models.ray_samplers import BaseSampler
+from pprndr.ray_marching import render_weight_from_density
+
+__all__ = ["NeRF"]
+
+
+@manager.MODELS.add_component
+class NeRF(nn.Layer):
+    def __init__(self,
+                 coarse_ray_sampler: BaseSampler,
+                 fine_ray_sampler: BaseSampler,
+                 field: BaseField,
+                 rgb_renderer: nn.Layer,
+                 coarse_rgb_loss: nn.Layer = nn.MSELoss(),
+                 fine_rgb_loss: nn.Layer = nn.MSELoss()):
+        super(NeRF, self).__init__()
+
+        self.coarse_ray_sampler = coarse_ray_sampler
+        self.fine_ray_sampler = fine_ray_sampler
+        self.field = field
+        self.rgb_renderer = rgb_renderer
+        self.coarse_rgb_loss = coarse_rgb_loss
+        self.fine_rgb_loss = fine_rgb_loss
+
+    def _forward(self,
+                 sample: Union[Tuple[RayBundle, dict], RayBundle],
+                 cur_iter: int = None) -> Dict[str, paddle.Tensor]:
+        if self.training:
+            ray_bundle, pixel_batch = sample
+        else:
+            ray_bundle = sample
+
+        coarse_samples = self.coarse_ray_sampler(
+            ray_bundle, cur_iter=cur_iter, density_fn=self.field.density_fn)
+
+        coarse_outputs = self.field(coarse_samples)
+        coarse_weights = render_weight_from_density(
+            t_starts=coarse_samples.frustums.starts,
+            t_ends=coarse_samples.frustums.ends,
+            densities=coarse_outputs["density"],
+            packed_info=coarse_samples.packed_info)
+
+        coarse_rgb, coarse_visibility_mask = self.rgb_renderer(
+            coarse_outputs["rgb"],
+            coarse_weights,
+            ray_indices=coarse_samples.ray_indices,
+            num_rays=ray_bundle.num_rays,
+            return_visibility=self.training)
+
+        fine_samples = self.fine_ray_sampler(
+            ray_bundle=ray_bundle,
+            ray_samples=coarse_samples,
+            weights=coarse_weights)
+        num_fine_samples = self.fine_ray_sampler.num_samples
+        if getattr(self.fine_ray_sampler, "include_original", False):
+            num_coarse_samples = self.coarse_ray_sampler.num_samples
+            num_fine_samples = num_fine_samples + num_coarse_samples + 1
+
+        fine_outputs = self.field(fine_samples)
+        fine_weights = render_weight_from_density(
+            t_starts=fine_samples.frustums.starts,
+            t_ends=fine_samples.frustums.ends,
+            densities=fine_outputs["density"],
+            packed_info=fine_samples.packed_info)
+
+        fine_rgb, fine_visibility_mask = self.rgb_renderer(
+            fine_outputs["rgb"],
+            fine_weights,
+            ray_indices=fine_samples.ray_indices,
+            num_rays=ray_bundle.num_rays,
+            return_visibility=self.training)
+
+        outputs = dict(rgb=fine_rgb)
+
+        if self.training:
+            coarse_rgb_loss = self.coarse_rgb_loss(
+                coarse_rgb[coarse_visibility_mask],
+                pixel_batch["pixels"][coarse_visibility_mask])
+            fine_rgb_loss = self.fine_rgb_loss(
+                fine_rgb[fine_visibility_mask],
+                pixel_batch["pixels"][fine_visibility_mask])
+            outputs["loss"] = dict(
+                coarse_rgb_loss=.1 * coarse_rgb_loss,
+                fine_rgb_loss=fine_rgb_loss)
+            outputs["num_samples_per_batch"] = num_fine_samples
+
+        return outputs
+
+    def forward(self, *args, **kwargs):
+        if hasattr(self, "amp_cfg_") and self.training:
+            with paddle.amp.auto_cast(**self.amp_cfg_):
+                return self._forward(*args, **kwargs)
+        return self._forward(*args, **kwargs)

--- a/contrib/PaddleRendering/pprndr/optimizers/lr_schedulers.py
+++ b/contrib/PaddleRendering/pprndr/optimizers/lr_schedulers.py
@@ -57,3 +57,24 @@ class CustomExponentialDecay(LambdaDecay):
 
         super(CustomExponentialDecay, self).__init__(
             lr_init, lr_lambda=lr_lambda)
+
+
+@manager.LR_SCHEDULERS.add_component
+class ExponentialDecay(LambdaDecay):
+    """Exponential learning rate decay function.
+        Refer to https://github.com/bmild/nerf/blob/18b8aebda6700ed659cb27a0c348b737a5f6ab60/run_nerf.py#L707
+        for details.
+
+        Args:
+            lr_init: The initial learning rate.
+            decay_rate: The decay rate.
+            decay_steps: The decays number of steps.
+    """
+
+    def __init__(self, lr_init, delay_rate, delay_steps):
+        def lr_lambda(step):
+            multiplier = (step / delay_steps
+                          )  # the multiplier is with the initial learning rate
+            return delay_rate**multiplier
+
+        super(ExponentialDecay, self).__init__(lr_init, lr_lambda=lr_lambda)


### PR DESCRIPTION
添加vanilla nerf，主要参考mip-nerf，去除了IPE，同时粗采样num samples改为64，MLP的输入维度等超参数也进行了相应修改，增加了与原repo一致的学习率变化方法。