### PR TITLE
reset do_bind default value to False because it will close the terminate unexpectedlly when users break off the training process

### DIFF
--- a/paddle3d/apis/trainer.py
+++ b/paddle3d/apis/trainer.py
@@ -124,7 +124,7 @@ class Trainer:
             profiler_options: Optional[dict] = None,
             dataloader_fn: Union[dict, Callable] = dict(),
             amp_cfg: Optional[dict] = None,
-            do_bind: Optional[bool] = True):
+            do_bind: Optional[bool] = False):
 
         self.model = model
         self.optimizer = optimizer


### PR DESCRIPTION
Reset `do_bind` default value to `False` because it will close the terminate unexpectedlly when users break off the training process.