### PR TITLE
Reorganize and cleanup code

### DIFF
--- a/contrib/PaddleRendering/configs/neus/llff_data.yml
+++ b/contrib/PaddleRendering/configs/neus/llff_data.yml
@@ -1,5 +1,5 @@
 iters: 300000
-image_batch_size: 1
+image_batch_size: -1
 ray_batch_size: 256
 eval_pixel_stride: 1
 image_resampling_interval: -1
@@ -23,7 +23,7 @@ train_dataset:
   transforms:
     - type: LoadImage
     - type: Normalize
-  split: "train"
+  split: train
 
 val_dataset:
   type: LLFFDataset
@@ -33,10 +33,8 @@ val_dataset:
   camera_scale_factor: 1.0
   camera_axis_convention: OpenCV
   image_coords_offset: 0
-  eval_with_grad: True  # must be set True to enable rendering normal_map in evaluation mode.
   eval_to_cpu: True
-  max_eval_num: 3
-  validate_mesh: "neus_style"
+  validate_mesh: neus_style
   mesh_resolution: 256
   world_space_for_mesh: False
   bound_min: [-1.0, -1.0, -1.0]
@@ -46,7 +44,7 @@ val_dataset:
   transforms:
     - type: LoadImage
     - type: Normalize
-  split: "val"
+  split: val
 
 optimizer:
   type: Adam
@@ -66,7 +64,6 @@ lr_scheduler:
 model:
   type: NeuS
   fine_sampling_steps: 4
-  background_rgb: null
   loss_weight_color: 1.0
   loss_weight_idr: 0.1
   loss_weight_mask: 0.0
@@ -126,14 +123,14 @@ model:
       num_layers: 9
       hidden_dim: 256
       skip_layers: [4]
-      skip_connection_way: "concat_in"   # concat_in, concat_out
+      skip_connection_way: concat_in   # concat_in, concat_out
       skip_connection_scale: 1.4142135   # np.sqrt(2)
       with_bias: True # to be set to 0
       activation:
         type: Softplus
         beta: 100
         threshold: 20
-      output_activation: "none"
+      output_activation: none
       weight_init:
         type: GeometricInit
         bias: 0.5
@@ -148,8 +145,8 @@ model:
       hidden_dim: 256
       skip_layers: null
       with_bias: True
-      activation: "relu"
-      output_activation: "sigmoid"
+      activation: relu
+      output_activation: sigmoid
       weight_normalization: True
 
   global_field:
@@ -176,8 +173,8 @@ model:
       num_layers: 8
       hidden_dim: 256
       skip_layers: [5]
-      activation: "relu"
-      output_activation: "relu"
+      activation: relu
+      output_activation: relu
       weight_normalization: False
 
     density_head: # Called alpha_linear though.
@@ -185,7 +182,7 @@ model:
       input_dim: 256
       output_dim: 1
       num_layers: 1
-      output_activation: "none"
+      output_activation: none
 
     color_head:
       type: MLP
@@ -194,7 +191,7 @@ model:
       hidden_dim: 128
       num_layers: 2
       activation: relu
-      output_activation: "sigmoid"
+      output_activation: sigmoid
 
   rgb_renderer:
     type: RGBRenderer

--- a/contrib/PaddleRendering/configs/neus/llff_data.yml
+++ b/contrib/PaddleRendering/configs/neus/llff_data.yml
@@ -134,7 +134,10 @@ model:
         beta: 100
         threshold: 20
       output_activation: "none"
-      weight_init: ["geometric_init", 0.5, True] # the last one indicates if num_freqs > 0
+      weight_init:
+        type: GeometricInit
+        bias: 0.5
+        multi_res: True
       weight_normalization: True
 
     color_network:

--- a/contrib/PaddleRendering/configs/neus/llff_data.yml
+++ b/contrib/PaddleRendering/configs/neus/llff_data.yml
@@ -55,11 +55,15 @@ optimizer:
   multi_precision: False
 
 lr_scheduler:
-  type: NeuSLRDecay
-  lr_init: 0.0005
-  warm_up_end: 5000
-  learning_rate_alpha: 0.05
-  max_steps: 300001
+  type: LinearWarmup
+  learning_rate:
+    type: CosineAnnealingDecay
+    learning_rate: 0.0005
+    T_max: 300000
+    eta_min: 2.5e-05
+  warmup_steps: 5000
+  start_lr: 0.0
+  end_lr: 0.0005
 
 model:
   type: NeuS

--- a/contrib/PaddleRendering/pprndr/apis/config.py
+++ b/contrib/PaddleRendering/pprndr/apis/config.py
@@ -157,7 +157,7 @@ class Config(object):
 
     @property
     def image_batch_size(self) -> int:
-        return self.dic.get('batch_size', -1)
+        return self.dic.get('image_batch_size', -1)
 
     @property
     def ray_batch_size(self) -> int:

--- a/contrib/PaddleRendering/pprndr/apis/manager.py
+++ b/contrib/PaddleRendering/pprndr/apis/manager.py
@@ -20,7 +20,7 @@ from pprndr.utils.logger import logger
 
 __all__ = [
     "DATASETS", "TRANSFORMS", "MODELS", "ENCODERS", "RAYSAMPLERS", "LAYERS",
-    "FIELDS", "RENDERERS", "LR_SCHEDULERS", "METRICS"
+    "FIELDS", "RENDERERS", "LR_SCHEDULERS", "METRICS", "WEIGHT_INITIALIZERS"
 ]
 
 
@@ -149,3 +149,4 @@ LAYERS = ComponentManager(name="layers")
 RENDERERS = ComponentManager(name="renderers")
 LR_SCHEDULERS = ComponentManager(name="lr_schedulers")
 METRICS = ComponentManager(name="metrics")
+WEIGHT_INITIALIZERS = ComponentManager(name="weight_initializers")

--- a/contrib/PaddleRendering/pprndr/apis/pipeline.py
+++ b/contrib/PaddleRendering/pprndr/apis/pipeline.py
@@ -82,6 +82,7 @@ def training_step(model: paddle.nn.Layer,
     return outputs
 
 
+@paddle.no_grad()
 def inference_step(model: paddle.nn.Layer,
                    ray_bundle: RayBundle,
                    ray_batch_size: int,

--- a/contrib/PaddleRendering/pprndr/cameras/rays.py
+++ b/contrib/PaddleRendering/pprndr/cameras/rays.py
@@ -58,6 +58,8 @@ class Frustums(object):
 
     @property
     def bin_points(self) -> paddle.Tensor:
+        # TODO: [Warning] If bin_points is passed to networks,
+        #  note that there is a mismatch between the shapes of bin_points and shape of directions.
         if self.origins.ndim == 3:
             origins = paddle.concat([self.origins, self.origins[:, -1:, :]],
                                     axis=-2)

--- a/contrib/PaddleRendering/pprndr/cameras/rays.py
+++ b/contrib/PaddleRendering/pprndr/cameras/rays.py
@@ -58,13 +58,21 @@ class Frustums(object):
 
     @property
     def bin_points(self) -> paddle.Tensor:
-        origins = paddle.concat(
-            [self.origins, self.origins[:, -1, :].unsqueeze(axis=1)], axis=1)
-        directions = paddle.concat(
-            [self.directions, self.directions[:, -1, :].unsqueeze(axis=1)],
-            axis=1)
-        points = origins + directions * \
-                 paddle.concat((self.starts, self.ends[:, -1, None]), axis=1)
+        if self.origins.ndim == 3:
+            origins = paddle.concat([self.origins, self.origins[:, -1:, :]],
+                                    axis=-2)
+            directions = paddle.concat(
+                [self.directions, self.directions[:, -1:, :]], axis=-2)
+            points = origins + directions * paddle.concat(
+                [self.starts, self.ends[:, -1:, :]],
+                axis=-2)  # [num_rays, num_samples + 1, 3]
+        else:
+            origins = paddle.repeat_interleave(self.origins, repeats=2, axis=-2)
+            directions = paddle.repeat_interleave(
+                self.directions, repeats=2, axis=-2)
+            intervals = paddle.stack([self.starts, self.ends], axis=-2).flatten(
+                -3, -2)
+            points = origins + directions * intervals  # [num_total_samples * 2, 3]
 
         return points
 
@@ -164,8 +172,6 @@ class RaySamples:
             directions = self.frustums.directions
             pixel_area = self.frustums.pixel_area
             camera_ids = self.camera_ids
-            spacing_bins = None
-            spacing2euclidean_fn = None
 
             for i, sample in enumerate(sample_list):
                 origin_pad = sample.frustums.origins[:, -1:, :]

--- a/contrib/PaddleRendering/pprndr/data/datasets/blender.py
+++ b/contrib/PaddleRendering/pprndr/data/datasets/blender.py
@@ -50,7 +50,6 @@ class BlenderDataset(BaseDataset):
                  camera_scale_factor: float = 1.0,
                  background_color: Union[str, list, tuple] = None,
                  image_coords_offset: float = 0.5,
-                 max_eval_num: int = None,
                  split: str = "train",
                  load_normals: bool = False):
         super(BlenderDataset, self).__init__()
@@ -59,7 +58,6 @@ class BlenderDataset(BaseDataset):
         self.transforms = Compose(transforms) if transforms else None
         self.camera_scale_factor = float(camera_scale_factor)
         self.image_coords_offset = image_coords_offset
-        self.max_eval_num = max_eval_num
         if background_color is not None:
             self.background_color = np.array(
                 get_color(background_color), dtype=np.float32)

--- a/contrib/PaddleRendering/pprndr/data/datasets/llff.py
+++ b/contrib/PaddleRendering/pprndr/data/datasets/llff.py
@@ -53,10 +53,8 @@ class LLFFDataset(BaseDataset):
                  camera_axis_convention: str = "OpenCV",
                  image_coords_offset: float = 0.0,
                  background_color: Union[str, list, tuple] = None,
-                 max_eval_num: Optional[int] = 5,
                  validate_mesh: Optional[str] = "neus_style",
                  mesh_resolution: Optional[str] = 64,
-                 eval_with_grad: Optional[bool] = True,
                  eval_to_cpu: Optional[bool] = False,
                  world_space_for_mesh: Optional[bool] = False,
                  bound_min: Optional[list] = None,
@@ -67,10 +65,8 @@ class LLFFDataset(BaseDataset):
         self.camera_axis_convention = camera_axis_convention
         self.render_cameras_name = render_cameras_name
         self.object_cameras_name = object_cameras_name
-        self.max_eval_num = max_eval_num
         self.validate_mesh = validate_mesh
         self.mesh_resolution = mesh_resolution
-        self.eval_with_grad = eval_with_grad
         self.eval_to_cpu = eval_to_cpu
         self.world_space_for_mesh = world_space_for_mesh
         self.bound_min = bound_min
@@ -79,7 +75,6 @@ class LLFFDataset(BaseDataset):
         self.transforms = Compose(transforms) if transforms else None
         self.camera_scale_factor = float(camera_scale_factor)
         self.image_coords_offset = float(image_coords_offset)
-        self.eval_with_grad = eval_with_grad
         if background_color is not None:
             self.background_color = np.array(
                 get_color(background_color), dtype=np.float32)
@@ -144,7 +139,6 @@ class LLFFDataset(BaseDataset):
             camera_dict['world_mat_%d' % idx].astype(np.float32)
             for idx in range(self.n_images)
         ]
-        scale_mats_np = []
 
         # scale_mat: used for coordinate normalization, we assume the scene to render is inside a unit sphere at origin.
         scale_mats_np = [

--- a/contrib/PaddleRendering/pprndr/models/fields/__init__.py
+++ b/contrib/PaddleRendering/pprndr/models/fields/__init__.py
@@ -12,9 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from .base import BaseField
+from .base import BaseDensityField, BaseSDFField
 from .instant_ngp_field import InstantNGPField
-from .nerf_field import NeRFField
+from .nerf_field import NeRFField, NeRFPPField
 from .plenoxels_field import PlenoxelGrid
 from .ref_nerf_field import RefNeRFField
 from .neus_fields import NeuSField

--- a/contrib/PaddleRendering/pprndr/models/fields/instant_ngp_field.py
+++ b/contrib/PaddleRendering/pprndr/models/fields/instant_ngp_field.py
@@ -26,12 +26,12 @@ except ModuleNotFoundError:
     from pprndr.cpp_extensions import trunc_exp
 
 from pprndr.geometries.scene_box import ContractionType
-from pprndr.models.fields import BaseField
+from pprndr.models.fields import BaseDensityField
 from pprndr.ray_marching import contract
 
 
 @manager.FIELDS.add_component
-class InstantNGPField(BaseField):
+class InstantNGPField(BaseDensityField):
     """
     Instant-NGP Field. Reference: https://nvlabs.github.io/instant-ngp/assets/mueller2022instant.pdf
 

--- a/contrib/PaddleRendering/pprndr/models/fields/nerf_field.py
+++ b/contrib/PaddleRendering/pprndr/models/fields/nerf_field.py
@@ -20,13 +20,13 @@ import paddle.nn.functional as F
 
 from pprndr.apis import manager
 from pprndr.cameras.rays import RaySamples
-from pprndr.models.fields import BaseField
+from pprndr.models.fields import BaseDensityField
 
-__all__ = ['NeRFField']
+__all__ = ['NeRFField', 'NeRFPPField']
 
 
 @manager.FIELDS.add_component
-class NeRFField(BaseField):
+class NeRFField(BaseDensityField):
     """
     NeRF Field. Reference: https://arxiv.org/abs/2003.08934
 
@@ -64,33 +64,13 @@ class NeRFField(BaseField):
         self.rgb_padding = rgb_padding
         self.use_integrated_encoding = use_integrated_encoding
 
-    def get_density(
-            self,
-            ray_samples: Union[RaySamples, paddle.Tensor],
-            which_pts: str = "mid_points",
-            manipulate_pts: str = None) -> Tuple[paddle.Tensor, paddle.Tensor]:
+    def get_density(self, ray_samples: Union[RaySamples, paddle.Tensor]
+                    ) -> Tuple[paddle.Tensor, paddle.Tensor]:
         if isinstance(ray_samples, RaySamples):
             if self.use_integrated_encoding:
-                assert (which_pts == "mid_points")
                 pos_inputs = ray_samples.frustums.gaussians
             else:
-                if which_pts == "mid_points":
-                    pos_inputs = ray_samples.frustums.positions
-                elif which_pts == "bin_points":
-                    pos_inputs = ray_samples.frustums.bin_points
-                else:
-                    raise ValueError(
-                        'which_pts should be either "mid_points" or "bin_points".'
-                    )
-            if manipulate_pts is not None:
-                assert (manipulate_pts in ["nerf_pp_outside_warp"])
-                if manipulate_pts == "nerf_pp_outside_warp":
-                    assert (self.pos_encoder.input_dims == 4)
-                    dis_to_center = paddle.linalg.norm(
-                        pos_inputs, p=2, axis=-1, keepdim=True).clip(1.0, 1e10)
-                    pos_inputs = paddle.concat(
-                        [pos_inputs / dis_to_center, 1.0 / dis_to_center],
-                        axis=-1)
+                pos_inputs = ray_samples.frustums.positions
         else:
             pos_inputs = ray_samples
         pos_embeddings = self.pos_encoder(pos_inputs)
@@ -119,3 +99,43 @@ class NeRFField(BaseField):
             color = color * (1. + 2. * self.rgb_padding) - self.rgb_padding
 
         return dict(rgb=color)
+
+
+@manager.FIELDS.add_component
+class NeRFPPField(NeRFField):
+    """
+    NeRF++ Field according to the paper.
+    """
+
+    def __init__(
+            self,
+            dir_encoder: nn.Layer,
+            pos_encoder: nn.Layer,
+            stem_net: nn.Layer,
+            density_head: nn.Layer,
+            color_head: nn.Layer,
+            density_noise: float = None,
+            density_bias: float = None,
+            rgb_padding: float = None,
+    ):
+        super(NeRFPPField, self).__init__(
+            dir_encoder=dir_encoder,
+            pos_encoder=pos_encoder,
+            stem_net=stem_net,
+            density_head=density_head,
+            color_head=color_head,
+            density_noise=density_noise,
+            density_bias=density_bias,
+            rgb_padding=rgb_padding,
+            use_integrated_encoding=False)
+
+    def get_density(self, ray_samples: RaySamples
+                    ) -> Tuple[paddle.Tensor, paddle.Tensor]:
+        # warp outsiders
+        positions = ray_samples.frustums.positions
+        dis_to_center = paddle.linalg.norm(
+            positions, p=2, axis=-1, keepdim=True).clip(1.0, 1e10)
+        pos_inputs = paddle.concat(
+            [positions / dis_to_center, 1.0 / dis_to_center], axis=-1)
+
+        return super(NeRFPPField, self).get_density(pos_inputs)

--- a/contrib/PaddleRendering/pprndr/models/fields/neus_fields.py
+++ b/contrib/PaddleRendering/pprndr/models/fields/neus_fields.py
@@ -12,12 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Dict, Tuple, Union
+from typing import Dict
 
+import numpy as np
 import paddle
 import paddle.nn as nn
-import paddle.nn.functional as F
-import numpy as np
+
 from pprndr.apis import manager
 from pprndr.cameras.rays import RaySamples
 
@@ -104,7 +104,6 @@ class NeuSField(BaseSDFField):
             ray_samples: RaySamples,
     ) -> paddle.Tensor:
         pts = ray_samples.frustums.positions
-        batch_size, n_samples, _ = pts.shape
         pts_norm = paddle.linalg.norm(pts, p=2, axis=-1, keepdim=True)
         inside_sphere = (pts_norm < 1.0).astype('float32').detach()
         relax_inside_sphere = (pts_norm < 1.2).astype('float32').detach()

--- a/contrib/PaddleRendering/pprndr/models/fields/neus_fields.py
+++ b/contrib/PaddleRendering/pprndr/models/fields/neus_fields.py
@@ -26,43 +26,15 @@ try:
 except ModuleNotFoundError:
     from pprndr.cpp_extensions import trunc_exp
 
-from pprndr.models.fields import BaseField, NeRFField
+from pprndr.models.fields import BaseSDFField
 
-__all__ = ["NeuSField", "NeRFPPField"]
-
-
-@manager.FIELDS.add_component
-class NeRFPPField(NeRFField):
-    """
-    NeRF++ Field according to the paper.
-    """
-
-    def __init__(
-            self,
-            dir_encoder: nn.Layer,
-            pos_encoder: nn.Layer,
-            stem_net: nn.Layer,
-            density_head: nn.Layer,
-            color_head: nn.Layer,
-            density_noise: float = None,
-            density_bias: float = None,
-            rgb_padding: float = None,
-    ):
-        super(NeRFPPField, self).__init__(
-            dir_encoder=dir_encoder,
-            pos_encoder=pos_encoder,
-            stem_net=stem_net,
-            density_head=density_head,
-            color_head=color_head,
-            density_noise=density_noise,
-            density_bias=density_bias,
-            rgb_padding=rgb_padding)
+__all__ = ["NeuSField"]
 
 
 @manager.FIELDS.add_component
-class NeuSField(BaseField):
+class NeuSField(BaseSDFField):
     """
-    SDF and a rendring net
+    SDF and a rendering net
     """
 
     def __init__(self, pos_encoder: nn.Layer, view_encoder: nn.Layer,
@@ -88,92 +60,59 @@ class NeuSField(BaseField):
         signed_distances = outputs[:, :, :1]
         return signed_distances
 
-    def get_sdf_output(
-            self,
-            ray_samples: RaySamples,
-            which_pts: str = "mid_points"  # or bin_points
-    ):
-        if which_pts == "mid_points":
-            pts = ray_samples.frustums.positions
-        else:
-            assert (which_pts == "bin_points")
-            pts = ray_samples.frustums.bin_points
+    def get_sdf(self, ray_samples: RaySamples, compute_grad: bool = True):
+        requires_grad = compute_grad or paddle.is_grad_enabled()
+        with paddle.set_grad_enabled(requires_grad):
+            if isinstance(ray_samples, RaySamples):
+                pos_inputs = ray_samples.frustums.positions
+            else:
+                pos_inputs = ray_samples
 
-        pts = pts * self.scale
-        pts = self.pos_encoder(pts)
-        outputs = self.sdf_network(pts)
-        signed_distances = outputs[:, :, :1] / self.scale
-        sdf_features = outputs[:, :, 1:]
-        return signed_distances, sdf_features
+            pos_inputs = pos_inputs * self.scale
+            pos_inputs.stop_gradient = not requires_grad
+            pos_embeddings = self.pos_encoder(pos_inputs)
+            embeddings = self.sdf_network(pos_embeddings)
+            signed_distances = embeddings[..., :1] / self.scale
 
-    def get_gradients(self,
-                      ray_samples: RaySamples,
-                      which_pts: str = "mid_points") -> paddle.Tensor:
-        if which_pts == "mid_points":
-            pts = ray_samples.frustums.positions
-        else:
-            assert (which_pts == "bin_points")
-            pts = ray_samples.frustums.bin_points
-        pts = pts * self.scale
-        pts.stop_gradient = False
-        pts_enc = self.pos_encoder(pts)
-        signed_distances = self.sdf_network(pts_enc)[:, :, :1] / self.scale
-        d_outputs = paddle.ones_like(signed_distances)  # How to set it no_grad?
-        d_outputs.stop_gradient = False
-        gradients = paddle.grad(
-            outputs=signed_distances,
-            inputs=pts,
-            grad_outputs=d_outputs,
-            create_graph=True,
-            retain_graph=True,
-            only_inputs=True)[0]
+            gradients = paddle.grad(
+                outputs=signed_distances,
+                inputs=pos_inputs,
+                grad_outputs=paddle.ones_like(signed_distances),
+                create_graph=True,
+                retain_graph=True,
+                only_inputs=True)[0] if requires_grad else None
 
-        return gradients
+        sdf_features = embeddings[..., 1:]
 
-    def get_colors(self,
-                   ray_samples: RaySamples,
-                   gradients: paddle.Tensor,
-                   sdf_features: paddle.Tensor,
-                   which_pts: str = "mid_points") -> paddle.Tensor:
-        # Get inputs
-        if which_pts == "mid_points":
-            pts = ray_samples.frustums.positions
-        else:
-            assert (which_pts == "bin_points")
-            pts = ray_samples.frustums.bin_points
+        return signed_distances, (sdf_features, gradients)
 
-        dirs = ray_samples.frustums.directions
+    def get_outputs(self, ray_samples: RaySamples,
+                    geo_features: paddle.Tensor) -> Dict[str, paddle.Tensor]:
+        positions = ray_samples.frustums.positions
+        directions = ray_samples.frustums.directions
 
-        # Encode view_dirs
-        dirs = self.view_encoder(dirs)  # (view[B, 3] & encoded(view)[B, 3 * 4])
-        rendering_input = paddle.concat([pts, dirs, gradients, sdf_features],
-                                        axis=-1)
+        embeddings, gradients = geo_features
+        directions = self.view_encoder(directions)
+        rendering_input = paddle.concat(
+            [positions, directions, gradients, embeddings], axis=-1)
         color = self.color_network(rendering_input)
 
-        return color
+        return dict(rgb=color, gradients=gradients)
 
-    def get_inside_filter_by_norm(self,
-                                  ray_samples: RaySamples,
-                                  which_pts: str = "mid_points"
-                                  ) -> paddle.Tensor:
-        if which_pts == "mid_points":
-            pts = ray_samples.frustums.positions
-        else:
-            assert (which_pts == "bin_points")
-            pts = ray_samples.frustums.bin_points
+    def get_inside_filter_by_norm(
+            self,
+            ray_samples: RaySamples,
+    ) -> paddle.Tensor:
+        pts = ray_samples.frustums.positions
         batch_size, n_samples, _ = pts.shape
         pts_norm = paddle.linalg.norm(pts, p=2, axis=-1, keepdim=True)
         inside_sphere = (pts_norm < 1.0).astype('float32').detach()
         relax_inside_sphere = (pts_norm < 1.2).astype('float32').detach()
         return inside_sphere, relax_inside_sphere
 
-    def get_inv_s(self, batch_size: int, n_samples: int):
-        inv_s = self.deviation_network(paddle.zeros([1, 3]))[:, :1].clip(
-            1e-6, 1e6)
-        inv_s = inv_s.unsqueeze(axis=-1)
-        inv_s = paddle.repeat_interleave(inv_s, batch_size, axis=0)
-        inv_s = paddle.repeat_interleave(inv_s, n_samples, axis=1)
-        return inv_s
+    @property
+    def inv_s(self):
+        return self.deviation_network().clip(1e-6, 1e6)
 
 
 class SingleVarianceNetwork(nn.Layer):
@@ -185,5 +124,5 @@ class SingleVarianceNetwork(nn.Layer):
                 np.array([init_val])))
         self.add_parameter('variance', variance)
 
-    def forward(self, x):
-        return paddle.ones([len(x), 1]) * paddle.exp(self.variance * 10.0)
+    def forward(self):
+        return paddle.exp(self.variance * 10.0)

--- a/contrib/PaddleRendering/pprndr/models/fields/plenoxels_field.py
+++ b/contrib/PaddleRendering/pprndr/models/fields/plenoxels_field.py
@@ -27,13 +27,13 @@ except ModuleNotFoundError:
     from pprndr.cpp_extensions import sh_encoder
 
 from pprndr.geometries import ContractionType
-from pprndr.models.fields import BaseField
+from pprndr.models.fields import BaseDensityField
 
 __all__ = ["PlenoxelGrid"]
 
 
 @manager.FIELDS.add_component
-class PlenoxelGrid(BaseField):
+class PlenoxelGrid(BaseDensityField):
     def __init__(self,
                  radius: float = 1.3,
                  sh_degree: int = 2,

--- a/contrib/PaddleRendering/pprndr/models/fields/ref_nerf_field.py
+++ b/contrib/PaddleRendering/pprndr/models/fields/ref_nerf_field.py
@@ -26,13 +26,13 @@ try:
 except ModuleNotFoundError:
     from pprndr.cpp_extensions import trunc_exp
 
-from pprndr.models.fields import BaseField
+from pprndr.models.fields import BaseDensityField
 
 __all__ = ['RefNeRFField']
 
 
 @manager.FIELDS.add_component
-class RefNeRFField(BaseField):
+class RefNeRFField(BaseDensityField):
     """
     Ref-NeRF Field. Reference: https://arxiv.org/abs/2112.03907
 

--- a/contrib/PaddleRendering/pprndr/models/fields/tensorf_field.py
+++ b/contrib/PaddleRendering/pprndr/models/fields/tensorf_field.py
@@ -20,14 +20,14 @@ import paddle.nn.functional as F
 
 from pprndr.apis import manager
 from pprndr.cameras.rays import RaySamples
-from pprndr.models.fields import BaseField
+from pprndr.models.fields import BaseDensityField
 from pprndr.models.encoders import SHEncoder, TensorCPEncoder, TensorVMEncoder, TriplaneEncoder
 
 __all__ = ['TensoRFField']
 
 
 @manager.FIELDS.add_component
-class TensoRFField(BaseField):
+class TensoRFField(BaseDensityField):
     """
     TensoRF Field. Reference: https://arxiv.org/abs/2003.08934
 

--- a/contrib/PaddleRendering/pprndr/models/instant_ngp/instant_ngp.py
+++ b/contrib/PaddleRendering/pprndr/models/instant_ngp/instant_ngp.py
@@ -19,7 +19,7 @@ import paddle.nn as nn
 
 from pprndr.apis import manager
 from pprndr.cameras.rays import RayBundle
-from pprndr.models.fields import BaseField
+from pprndr.models.fields import BaseDensityField
 from pprndr.models.ray_samplers import BaseSampler
 from pprndr.ray_marching import render_weight_from_density
 
@@ -30,7 +30,7 @@ __all__ = ["InstantNGP"]
 class InstantNGP(nn.Layer):
     def __init__(self,
                  ray_sampler: BaseSampler,
-                 field: BaseField,
+                 field: BaseDensityField,
                  rgb_renderer: nn.Layer,
                  rgb_loss: nn.Layer = nn.MSELoss()):
         super(InstantNGP, self).__init__()

--- a/contrib/PaddleRendering/pprndr/models/layers/__init__.py
+++ b/contrib/PaddleRendering/pprndr/models/layers/__init__.py
@@ -14,3 +14,4 @@
 
 from .grids import *
 from .mlps import *
+from .weight_initializers import *

--- a/contrib/PaddleRendering/pprndr/models/layers/weight_initializers.py
+++ b/contrib/PaddleRendering/pprndr/models/layers/weight_initializers.py
@@ -1,0 +1,106 @@
+#  Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License")
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import numpy as np
+import paddle.nn as nn
+
+from pprndr.apis import manager
+
+__all__ = ['GeometricInit']
+
+
+@manager.WEIGHT_INITIALIZERS.add_component
+class GeometricInit(object):
+    def __init__(self, bias: float, multi_res: bool):
+        self.bias = float(bias)
+        self.multi_res = multi_res
+
+    def initialize(self,
+                   layers: list,
+                   skip_layers: list = None,
+                   dims: list = None):
+        assert (len(layers) > 1)
+        for i, layer in enumerate(layers):
+            if i == len(layers) - 1:
+                dim = dims[i]  # input_dim of the last layer
+                which_layer = "last"
+
+            elif i == 0:
+                dim = dims[i + 1]  # output_dim of the first layer
+                which_layer = "first"
+
+            elif i in skip_layers:
+                dim = [dims[i + 1], (dims[0] - 3)]
+                which_layer = "skip"
+
+            else:
+                dim = dims[i + 1]
+                which_layer = "hidden"
+
+            self._initialize_layer(layer, dim, which_layer)
+
+    def _initialize_layer(self, layer, dim, which_layer):
+        assert (which_layer in ["first", "skip", "last", "hidden"])
+        if which_layer == "last":
+            # Init. weight
+            _weight = layer.weight.numpy()
+            _weight = np.random.normal(
+                np.sqrt(np.pi) / np.sqrt(dim), 0.0001, _weight.shape)
+            nn.initializer.Assign(_weight)(layer.weight)
+            if layer.bias is not None:
+                # Init bias
+                _bias = layer.bias.numpy()
+                _bias[...] = -self.bias
+                nn.initializer.Assign(_bias)(layer.bias)
+
+        elif which_layer == "first" and self.multi_res:
+            # Init. weight
+            # Note dim should be output dim of this layer
+            _weight = layer.weight.numpy()
+            _weight = np.random.normal(0.0,
+                                       np.sqrt(2) / np.sqrt(dim), _weight.shape)
+            _weight[3:, :] = 0.0
+
+            nn.initializer.Assign(_weight)(layer.weight)
+            if layer.bias is not None:
+                # Init bias
+                _bias = layer.bias.numpy()
+                _bias[...] = 0
+                nn.initializer.Assign(_bias)(layer.bias)
+
+        elif which_layer == "skip" and self.multi_res:
+            out_dim = dim[0]
+            embed_dim = dim[1]
+            # Init weight
+            _weight = layer.weight.numpy()
+            _weight = np.random.normal(0.0,
+                                       np.sqrt(2) / np.sqrt(out_dim),
+                                       _weight.shape)
+            _weight[-embed_dim:] = 0.0
+            nn.initializer.Assign(_weight)(layer.weight)
+            if layer.bias is not None:
+                # Init bias
+                _bias = layer.bias.numpy()
+                _bias[...] = 0.0
+                nn.initializer.Assign(_bias)(layer.bias)
+        else:
+            _weight = layer.weight.numpy()
+            _weight = np.random.normal(0.0,
+                                       np.sqrt(2) / np.sqrt(dim), _weight.shape)
+            nn.initializer.Assign(_weight)(layer.weight)
+            if layer.bias is not None:
+                # Init bias
+                _bias = layer.bias.numpy()
+                _bias[...] = 0.0
+                nn.initializer.Assign(_bias)(layer.bias)

--- a/contrib/PaddleRendering/pprndr/models/mip_nerf/mip_nerf.py
+++ b/contrib/PaddleRendering/pprndr/models/mip_nerf/mip_nerf.py
@@ -19,7 +19,7 @@ import paddle.nn as nn
 
 from pprndr.apis import manager
 from pprndr.cameras.rays import RayBundle
-from pprndr.models.fields import BaseField
+from pprndr.models.fields import BaseDensityField
 from pprndr.models.ray_samplers import BaseSampler
 from pprndr.ray_marching import render_weight_from_density
 
@@ -31,7 +31,7 @@ class MipNeRF(nn.Layer):
     def __init__(self,
                  coarse_ray_sampler: BaseSampler,
                  fine_ray_sampler: BaseSampler,
-                 field: BaseField,
+                 field: BaseDensityField,
                  rgb_renderer: nn.Layer,
                  coarse_rgb_loss: nn.Layer = nn.MSELoss(),
                  fine_rgb_loss: nn.Layer = nn.MSELoss()):

--- a/contrib/PaddleRendering/pprndr/models/nerf/nerf.py
+++ b/contrib/PaddleRendering/pprndr/models/nerf/nerf.py
@@ -19,7 +19,7 @@ import paddle.nn as nn
 
 from pprndr.apis import manager
 from pprndr.cameras.rays import RayBundle
-from pprndr.models.fields import BaseField
+from pprndr.models.fields import BaseDensityField
 from pprndr.models.ray_samplers import BaseSampler
 from pprndr.ray_marching import render_weight_from_density
 
@@ -31,7 +31,7 @@ class NeRF(nn.Layer):
     def __init__(self,
                  coarse_ray_sampler: BaseSampler,
                  fine_ray_sampler: BaseSampler,
-                 field: BaseField,
+                 field: BaseDensityField,
                  rgb_renderer: nn.Layer,
                  coarse_rgb_loss: nn.Layer = nn.MSELoss(),
                  fine_rgb_loss: nn.Layer = nn.MSELoss()):

--- a/contrib/PaddleRendering/pprndr/models/neus/neus.py
+++ b/contrib/PaddleRendering/pprndr/models/neus/neus.py
@@ -12,18 +12,17 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Optional
 
 import paddle
 import paddle.nn.functional as F
 import paddle.nn as nn
 import numpy as np
-import time
 import mcubes
 
 from pprndr.apis import manager
 from pprndr.cameras.rays import RayBundle
-from pprndr.models.fields import BaseField
+from pprndr.models.fields import BaseDensityField
 from pprndr.models.ray_samplers import BaseSampler
 from pprndr.ray_marching import render_alpha_from_densities, render_weights_from_alpha, render_alpha_from_sdf, \
     get_anneal_coeff, get_cosine_coeff
@@ -37,12 +36,11 @@ class NeuS(nn.Layer):
     def __init__(self,
                  coarse_ray_sampler: BaseSampler,
                  fine_ray_sampler: BaseSampler,
-                 outside_ray_sampler: BaseSampler,
-                 inside_field: BaseField,
-                 global_field: BaseField,
+                 inside_field: BaseDensityField,
+                 global_field: BaseDensityField,
                  rgb_renderer: nn.Layer,
+                 outside_ray_sampler: Optional[BaseSampler] = None,
                  fine_sampling_steps: int = 4,
-                 background_rgb=None,
                  loss_weight_color: float = 1.0,
                  loss_weight_idr: float = 1.0,
                  loss_weight_mask: float = 1.0,
@@ -55,7 +53,6 @@ class NeuS(nn.Layer):
         self.global_field = global_field
         self.rgb_renderer = rgb_renderer
         self.fine_sampling_steps = fine_sampling_steps
-        self.background_rgb = background_rgb
         self.loss_weight_color = loss_weight_color
         self.loss_weight_idr = loss_weight_idr
         self.loss_weight_mask = loss_weight_mask
@@ -83,8 +80,8 @@ class NeuS(nn.Layer):
         if self.num_importance > 0:
             num_inside = num_inside + self.num_importance
             with paddle.no_grad():
-                signed_distances, sdf_features = self.inside_field.get_sdf_output(
-                    ray_samples_inside, which_pts="bin_points")
+                signed_distances = self.inside_field.sdf_fn(
+                    ray_samples_inside.frustums.bin_points)
 
                 for i in range(self.fine_sampling_steps):
                     batch_size = ray_samples_inside.spacing_bins.shape[0]
@@ -115,8 +112,8 @@ class NeuS(nn.Layer):
                         [ray_samples_inside_new], ray_bundle, mode="sort")
 
                     if i + 1 != self.fine_sampling_steps:
-                        new_signed_distances, _ = self.inside_field.get_sdf_output(
-                            ray_samples_inside_new, which_pts="bin_points")
+                        new_signed_distances = self.inside_field.sdf_fn(
+                            ray_samples_inside_new.frustums.bin_points)
 
                         signed_distances = paddle.concat(
                             [signed_distances, new_signed_distances], axis=-2)
@@ -133,68 +130,44 @@ class NeuS(nn.Layer):
                             batch_id, index)].reshape(
                                 [batch_size, num_inside_for_step_i, 1])
 
-        num_outside = self.outside_ray_sampler.num_samples
-        if num_outside > 0:
-            ray_samples_outside = self.outside_ray_sampler(
-                ray_bundle)  # Sampling outside
-            ray_samples = ray_samples_inside.merge_samples(
-                [ray_samples_outside], mode="force_concat")
-
-            # Compute densities and colors in the global field
-            global_densities, embeddings = self.global_field.get_density(
-                ray_samples,
-                which_pts="mid_points",
-                manipulate_pts="nerf_pp_outside_warp")
-            global_colors = self.global_field.get_outputs(
-                ray_samples, embeddings)
-
-            global_alphas = render_alpha_from_densities(
-                ray_samples=ray_samples, densities=global_densities)
-        else:
-            global_colors = None
-            global_alphas = None
-
         # Get inside field (SDF + RenderNet) outputs.
-        batch_size, n_samples, _ = ray_samples_inside.frustums.positions.shape
+        inside_outputs = self.inside_field(ray_samples_inside)
 
-        signed_distances, sdf_features = self.inside_field.get_sdf_output(
-            ray_samples_inside)
+        anneal_coeff = get_anneal_coeff(
+            ray_samples_inside, inside_outputs["gradients"], cur_iter,
+            self.anneal_end if self.training else 0.0)  # cos_anneal
 
-        gradients = self.inside_field.get_gradients(ray_samples_inside)
-
-        inside_colors = self.inside_field.get_colors(ray_samples_inside,
-                                                     gradients, sdf_features)
-
-        if not self.training:
-            self.anneal_end = 0.0
-        anneal_coeff = get_anneal_coeff(ray_samples_inside, gradients, cur_iter,
-                                        self.anneal_end)  # cos_anneal
-
-        inv_s = self.inside_field.get_inv_s(batch_size, n_samples)
         inside_alphas = render_alpha_from_sdf(
-            ray_samples_inside, signed_distances, inv_s, anneal_coeff)
+            ray_samples_inside, inside_outputs["sdf"], self.inside_field.inv_s,
+            anneal_coeff)
 
         # Filtering points by their norm
         inside_sphere, relax_inside_sphere = self.inside_field.get_inside_filter_by_norm(
             ray_samples_inside)
 
         # Get the final alpha and color.
-        if global_alphas is not None:
-            assert global_colors is not None
-            alphas = inside_alphas * inside_sphere + global_alphas[:, :
-                                                                   num_inside, :] * (
-                                                                       1.0 -
-                                                                       inside_sphere
-                                                                   )
-            alphas = paddle.concat([alphas, global_alphas[:, num_inside:, :]],
+        if self.outside_ray_sampler is not None:
+            ray_samples_outside = self.outside_ray_sampler(
+                ray_bundle)  # Sampling outside
+            global_ray_samples = ray_samples_inside.merge_samples(
+                [ray_samples_outside], mode="force_concat")
+
+            global_outputs = self.global_field(global_ray_samples)
+            global_alphas = render_alpha_from_densities(
+                ray_samples=global_ray_samples,
+                densities=global_outputs["density"])
+
+            alphas = inside_alphas * inside_sphere + global_alphas[
+                ..., :num_inside, :] * (1.0 - inside_sphere)
+            alphas = paddle.concat([alphas, global_alphas[..., num_inside:, :]],
                                    axis=1)
-            colors = inside_colors * inside_sphere + \
-                     global_colors["rgb"][:, :num_inside, :] * (1.0 - inside_sphere)
+            colors = inside_outputs["rgb"] * inside_sphere + global_outputs[
+                "rgb"][..., :num_inside, :] * (1.0 - inside_sphere)
             colors = paddle.concat(
-                [colors, global_colors["rgb"][:, num_inside:, :]], axis=1)
+                [colors, global_outputs["rgb"][:, num_inside:, :]], axis=1)
         else:
             alphas = inside_alphas
-            colors = inside_colors
+            colors = inside_outputs["rgb"]
 
         # Compute weights from alpha
         alphas = alphas.squeeze(-1)
@@ -207,15 +180,13 @@ class NeuS(nn.Layer):
             colors, weights, return_visibility=self.training)
 
         weights_sum = weights.squeeze(axis=-1).sum(axis=-1, keepdim=True)
-        if self.background_rgb is not None:
-            rgbs = rgbs + self.background_rgb * (1 - weights_sum)
 
         outputs = dict(rgb=rgbs)
 
         if self.training:
             # Eikonal loss
-            gradient_error = (
-                paddle.linalg.norm(gradients, p=2, axis=-1) - 1.0)**2
+            gradient_error = (paddle.linalg.norm(
+                inside_outputs["gradients"], p=2, axis=-1) - 1.0)**2
             gradient_error = gradient_error.unsqueeze(-1)
 
             eikonal_loss = (relax_inside_sphere * gradient_error).sum() / (
@@ -237,11 +208,12 @@ class NeuS(nn.Layer):
 
         num_samples_all = num_inside
 
-        if num_outside is not None:
-            num_samples_all += num_outside
+        if self.outside_ray_sampler is not None:
+            num_samples_all += self.outside_ray_sampler.num_samples
 
         outputs["num_samples_per_batch"] = num_samples_all
-        normals = gradients * weights[:, :num_inside, :] * inside_sphere
+        normals = inside_outputs[
+            "gradients"] * weights[:, :num_inside, :] * inside_sphere
 
         normals = paddle.sum(normals, axis=1)
         outputs["normals"] = normals
@@ -268,7 +240,6 @@ class NeuS(nn.Layer):
             for xi, xs in enumerate(X):
                 for yi, ys in enumerate(Y):
                     for zi, zs in enumerate(Z):
-                        t1 = time.time()
                         xx, yy, zz = paddle.meshgrid(xs, ys, zs)
                         pts = paddle.concat([
                             xx.reshape((-1, 1)),

--- a/contrib/PaddleRendering/pprndr/models/neus/neus.py
+++ b/contrib/PaddleRendering/pprndr/models/neus/neus.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Dict, Tuple, Union
+from typing import Dict, Tuple
 
 import paddle
 import paddle.nn.functional as F
@@ -230,13 +230,10 @@ class NeuS(nn.Layer):
             mask_loss = F.binary_cross_entropy(
                 weights_sum.clip(1e-3, 1.0 - 1e-3), ones)
 
-            combined_loss = rgb_loss * self.loss_weight_color + \
-                            eikonal_loss * self.loss_weight_idr + \
-                            mask_loss * self.loss_weight_mask
             outputs["loss"] = dict(
-                rgb_loss=rgb_loss,
-                eikonal_loss=eikonal_loss,
-                mask_loss=mask_loss)
+                rgb_loss=self.loss_weight_color * rgb_loss,
+                eikonal_loss=self.loss_weight_idr * eikonal_loss,
+                mask_loss=self.loss_weight_mask * mask_loss)
 
         num_samples_all = num_inside
 
@@ -246,7 +243,7 @@ class NeuS(nn.Layer):
         outputs["num_samples_per_batch"] = num_samples_all
         normals = gradients * weights[:, :num_inside, :] * inside_sphere
 
-        normals = paddle.sum(normals, axis=1).cpu()
+        normals = paddle.sum(normals, axis=1)
         outputs["normals"] = normals
 
         return outputs

--- a/contrib/PaddleRendering/pprndr/models/plenoxels/plenoxels.py
+++ b/contrib/PaddleRendering/pprndr/models/plenoxels/plenoxels.py
@@ -19,7 +19,7 @@ import paddle.nn as nn
 
 from pprndr.apis import manager
 from pprndr.cameras.rays import RayBundle
-from pprndr.models.fields import BaseField
+from pprndr.models.fields import BaseDensityField
 from pprndr.models.ray_samplers import GridIntersectionSampler
 from pprndr.ray_marching import render_weight_from_density
 
@@ -30,7 +30,7 @@ __all__ = ["Plenoxels"]
 class Plenoxels(nn.Layer):
     def __init__(self,
                  ray_sampler: GridIntersectionSampler,
-                 field: BaseField,
+                 field: BaseDensityField,
                  rgb_renderer: nn.Layer,
                  rgb_loss: nn.Layer = nn.MSELoss()):
         super(Plenoxels, self).__init__()

--- a/contrib/PaddleRendering/pprndr/models/ray_samplers/spaced_samplers.py
+++ b/contrib/PaddleRendering/pprndr/models/ray_samplers/spaced_samplers.py
@@ -187,8 +187,7 @@ class NeuSOutsideSampler(BaseSampler):
             euclidean_bins=euclidean_bins.unsqueeze(-1),
             spacing_bins=bins.unsqueeze(-1),
             spacing2euclidean_fn=None,
-            positions=positions  # Made sure not to use middle points.
-        )
+            positions=positions)
         return ray_samples
 
 
@@ -212,7 +211,6 @@ euclidean_bins
                  spacing_end: float = 1.0,
                  stratified: bool = True,
                  unified_jittering: bool = False):
-        #self.num_samples = num_samples
 
         super(UniformSampler, self).__init__(
             spacing_fn=lambda x: x,

--- a/contrib/PaddleRendering/pprndr/models/ref_nerf/ref_nerf.py
+++ b/contrib/PaddleRendering/pprndr/models/ref_nerf/ref_nerf.py
@@ -20,7 +20,7 @@ import paddle.nn.functional as F
 
 from pprndr.apis import manager
 from pprndr.cameras.rays import RayBundle
-from pprndr.models.fields import BaseField
+from pprndr.models.fields import BaseDensityField
 from pprndr.models.ray_samplers import BaseSampler
 from pprndr.ray_marching import render_weight_from_density
 
@@ -33,7 +33,7 @@ class RefNeRF(nn.Layer):
             self,
             coarse_ray_sampler: BaseSampler,
             fine_ray_sampler: BaseSampler,
-            field: BaseField,
+            field: BaseDensityField,
             rgb_renderer: nn.Layer,
             coarse_rgb_loss: nn.Layer = nn.MSELoss(),
             fine_rgb_loss: nn.Layer = nn.MSELoss(),

--- a/contrib/PaddleRendering/pprndr/optimizers/lr_schedulers.py
+++ b/contrib/PaddleRendering/pprndr/optimizers/lr_schedulers.py
@@ -20,32 +20,8 @@ from paddle.optimizer.lr import LambdaDecay
 from pprndr.apis import manager
 
 __all__ = [
-    "CustomExponentialDecay", "ExponentialDecay", "FixationExponentialDecay",
-    "NeuSLRDecay"
+    "CustomExponentialDecay", "ExponentialDecay", "FixationExponentialDecay"
 ]
-
-
-@manager.LR_SCHEDULERS.add_component
-class NeuSLRDecay(LambdaDecay):
-    """
-    Will be added layer.
-    """
-
-    def __init__(self, lr_init, warm_up_end, learning_rate_alpha, max_steps):
-        def lr_lambda(step):
-            """
-            Lambda fun. for decay
-            """
-            if step < warm_up_end:
-                learning_factor = step / warm_up_end
-            else:
-                alpha = learning_rate_alpha
-                progress = (step - warm_up_end) / (max_steps - warm_up_end)
-                learning_factor = (np.cos(np.pi * progress) + 1.0) * 0.5 * \
-                                  (1 - alpha) + alpha
-            return learning_factor
-
-        super(NeuSLRDecay, self).__init__(lr_init, lr_lambda=lr_lambda)
 
 
 @manager.LR_SCHEDULERS.add_component

--- a/contrib/PaddleRendering/pprndr/ray_marching.py
+++ b/contrib/PaddleRendering/pprndr/ray_marching.py
@@ -12,19 +12,18 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import sys
 from typing import Any, Callable, Tuple
 
 import numpy as np
 import paddle
-import paddle.nn as nn
 from paddle.nn import functional as F
 
 try:
     import ray_marching_lib
 except ModuleNotFoundError:
     from pprndr.cpp_extensions import ray_marching_lib
-from pprndr.cameras.rays import Frustums, RayBundle, RaySamples
+
+from pprndr.cameras.rays import RaySamples
 from pprndr.geometries import ContractionType
 
 __all__ = [
@@ -32,7 +31,9 @@ __all__ = [
     "contract_inv", "transmittance_from_alpha", "unpack_info", "ray_marching",
     "pdf_ray_marching", "render_visibility", "pack_info",
     "render_weight_from_density", "accumulate_along_rays",
-    "render_alpha_from_densities", "render_alpha_from_sdf"
+    "render_alpha_from_densities", "render_alpha_from_sdf",
+    "render_weights_from_alpha", "render_alpha_from_sdf", "get_anneal_coeff",
+    "get_cosine_coeff"
 ]
 
 
@@ -364,29 +365,33 @@ def get_anneal_coeff(ray_samples: RaySamples = None,
 def get_cosine_coeff(ray_samples: RaySamples = None,
                      signed_distance: paddle.Tensor = None,
                      radius_filter: float = None) -> paddle.Tensor:
-    if radius_filter is not None:
-        inside_pts = ray_samples.frustums.bin_points
-        radius = paddle.linalg.norm(inside_pts, p=2, axis=-1, keepdim=True)
-        inside_sphere = (radius[:, :-1] < 1.0) | (radius[:, 1:] < 1.0)
+    if signed_distance.ndim == 3:
+        prev_sdf = signed_distance[:, :-1, :]  # [b, n_samples, 1]
+        next_sdf = signed_distance[:, 1:, :]  # [b, n_samples, 1]
+    else:
+        prev_sdf = signed_distance[::2, :]  # [n_total_samples, 1]
+        next_sdf = signed_distance[1::2, :]  # [n_total_samples, 1]
 
-    batch_size, n_samples_plus1, _ = ray_samples.frustums.bin_points.shape
-    signed_distance = signed_distance.reshape((batch_size, n_samples_plus1))
-    prev_sdf = signed_distance[:, :-1]  # [b, n_samples]
-    next_sdf = signed_distance[:, 1:]  # [b, n_samples]
-    prev_z_vals = ray_samples.frustums.starts  # [b, n_samples]
-    next_z_vals = ray_samples.frustums.ends  # [b, n_samples]
-    mid_sdf = (prev_sdf + next_sdf) * 0.5
+    prev_z_vals = ray_samples.frustums.starts  # [b, n_samples, 1] or [n_total_samples, 1]
+    next_z_vals = ray_samples.frustums.ends  # [b, n_samples, 1] or [n_total_samples, 1]
+
     cos_val = (next_sdf - prev_sdf) / (
-        next_z_vals - prev_z_vals + 1e-5).squeeze(axis=-1)  # [b, n_samples]
+        next_z_vals - prev_z_vals + 1e-5
+    )  # [b, n_samples, 1] or [n_total_samples, 1]
     prev_cos_val = paddle.concat(
-        [paddle.zeros([batch_size, 1]), cos_val[:, :-1]],
-        axis=-1)  # [b, n_samples]
-    cos_val = paddle.stack([prev_cos_val, cos_val], axis=-1)
-    cos_val = paddle.min(cos_val, axis=-1, keepdim=True)
+        [paddle.zeros_like(cos_val[..., :1, :]), cos_val[..., :-1, :]],
+        axis=-2)  # [b, n_samples, 1] or [n_total_samples, 1]
+    cos_val = paddle.concat([prev_cos_val, cos_val],
+                            axis=-1)  # [b, n_samples, 2]
+    cos_val = paddle.min(cos_val, axis=-1, keepdim=True)  # [b, n_samples, 1]
     cos_val = cos_val.clip(-1e3, 0.0)
 
     if radius_filter is not None:
+        inside_pts = ray_samples.frustums.bin_points
+        radius = paddle.linalg.norm(inside_pts, p=2, axis=-1, keepdim=True)
+        inside_sphere = (radius[..., :-1, :] < 1.0) | (radius[..., 1:, :] < 1.0)
         cos_val = cos_val * inside_sphere
+
     return cos_val
 
 

--- a/contrib/PaddleRendering/pprndr/ray_marching.py
+++ b/contrib/PaddleRendering/pprndr/ray_marching.py
@@ -401,7 +401,6 @@ def render_alpha_from_sdf(ray_samples,
                           coeff=1.0,
                           clip_alpha=True):
     # Note: coeff limits sdf interval
-    batch_size, n_vals, _ = signed_distances.shape  # [B, n_sdfs, 1]
     dists = ray_samples.frustums.ends - ray_samples.frustums.starts
     estimated_next_sdf = signed_distances + coeff * dists * 0.5
     estimated_prev_sdf = signed_distances - coeff * dists * 0.5

--- a/contrib/PaddleRendering/requirements.txt
+++ b/contrib/PaddleRendering/requirements.txt
@@ -9,4 +9,5 @@ rarfile
 visualdl
 easydict
 PyMCubes==0.1.2
+scipy>=1.0.0
 trimesh==3.9.8

--- a/contrib/PaddleRendering/requirements.txt
+++ b/contrib/PaddleRendering/requirements.txt
@@ -8,3 +8,5 @@ pillow
 rarfile
 visualdl
 easydict
+mcubes
+trimesh

--- a/contrib/PaddleRendering/requirements.txt
+++ b/contrib/PaddleRendering/requirements.txt
@@ -8,6 +8,6 @@ pillow
 rarfile
 visualdl
 easydict
+scipy==1.7.0
 PyMCubes==0.1.2
-scipy>=1.0.0
 trimesh==3.9.8

--- a/contrib/PaddleRendering/requirements.txt
+++ b/contrib/PaddleRendering/requirements.txt
@@ -8,5 +8,5 @@ pillow
 rarfile
 visualdl
 easydict
-mcubes
-trimesh
+PyMCubes==0.1.2
+trimesh==3.9.8

--- a/contrib/PaddleRendering/tools/evaluate.py
+++ b/contrib/PaddleRendering/tools/evaluate.py
@@ -84,10 +84,8 @@ def main(args):
         load_pretrained_model(cfg.model, args.model)
 
     eval_pixel_stride = dic.get("eval_pixel_stride", 1)
-    max_eval_num = getattr(dic["val_dataset"], "max_eval_num", None)
-    eval_with_grad = getattr(dic["val_dataset"], "eval_with_grad", False)
     eval_to_cpu = getattr(dic["val_dataset"], "eval_to_cpu", False)
-    image_coords_offset = getattr(dict["val_dataset"], "image_coords_offset",
+    image_coords_offset = getattr(dic["val_dataset"], "image_coords_offset",
                                   0.5)
 
     validate_mesh = getattr(dic["val_dataset"], "validate_mesh", None)
@@ -111,7 +109,6 @@ def main(args):
     trainer.evaluate(
         save_dir=os.path.join(os.path.split(args.model)[0], "renderings"),
         val_ray_batch_size=args.ray_batch_size,
-        max_eval_num=max_eval_num,
         validate_mesh=validate_mesh,
         mesh_resolution=mesh_resolution,
         pixel_stride=eval_pixel_stride,
@@ -119,7 +116,6 @@ def main(args):
         bound_min=bound_min,  # used for generating mesh
         bound_max=bound_max,  # used for generating mesh
         image_coords_offset=image_coords_offset,
-        eval_with_grad=eval_with_grad,
         eval_to_cpu=eval_to_cpu)
 
 


### PR DESCRIPTION
1. 原本的`BaseField`基类修改为`BaseDensityField`和`BaseSDFField`，分别针对渲染模型和重建模型
2. 去除`eval_with_grad`参数并优化相关逻辑，模型会自动根据当前场景需要判断是否保留计算图的梯度
3. 暂时移除指定`BaseDensityField`以及`BaseSDFField`的输入为`bin_points`还是`mid_points`的功能。原因：
    - `Frustums`返回`bin_points`的shape（[num_rays, num_samples_per_ray + 1, 3]）与其`origins`以及`directions`的shape（[num_rays, num_samples_per_ray, 3]）不匹配，而Field中的一些环节会涉及到三者之间的运算从而报错。
    - 目前使用中点还是端点是在模型中默认指定好的，模型并未提供相应参数允许用户自由选择
    
    后续视需求，可以重新设计并引入该功能。
4. 新增`WEIGHT_INITIALIZERS`模块，方便用户调用
5. 更新`requirements.txt`中的依赖