### PR TITLE
Fix to_static and amp of petrv2

### DIFF
--- a/paddle3d/apis/pipeline.py
+++ b/paddle3d/apis/pipeline.py
@@ -32,7 +32,7 @@ def parse_losses(losses):
         total_loss = losses
     elif isinstance(losses, dict):
         for loss_name, loss_value in losses.items():
-            log_loss[loss_name] = sum(loss_value)
+            log_loss[loss_name] = paddle.sum(loss_value)
         total_loss = sum(
             _loss_value for _loss_name, _loss_value in log_loss.items())
 

--- a/paddle3d/models/detection/petr/petr3d.py
+++ b/paddle3d/models/detection/petr/petr3d.py
@@ -142,7 +142,6 @@ class Petr3D(BaseMultiViewModel):
         self.neck = neck
         self.to_static = to_static
         if self.to_static:
-            self.pts_bbox_head.to_static = True
             for transformerlayer in self.pts_bbox_head.transformer.decoder.layers:
                 transformerlayer.use_recompute = False
             for backbonelayer in self.backbone.sublayers():
@@ -159,8 +158,10 @@ class Petr3D(BaseMultiViewModel):
                 InputSpec([12, 1024, 10, 25])
             ]]
             specs_backbone = [InputSpec([12, 3, 320, 800])]
-            apply_to_static(
-                to_static, self.pts_bbox_head, image_shape=specs_head)
+            if not self.pts_bbox_head.with_denoise:
+                self.pts_bbox_head.to_static = True
+                apply_to_static(
+                    to_static, self.pts_bbox_head, image_shape=specs_head)
             apply_to_static(
                 to_static, self.backbone, image_shape=specs_backbone)
             apply_to_static(to_static, self.neck, image_shape=specs_neck)
@@ -295,7 +296,7 @@ class Petr3D(BaseMultiViewModel):
                           gt_bboxes_ignore=None):
         """
         """
-        if self.to_static:
+        if self.to_static and not self.pts_bbox_head.with_denoise:
             timestamp = paddle.to_tensor(np.asarray(img_metas[0]['timestamp']))
             outs = self.pts_bbox_head(
                 pts_feats,


### PR DESCRIPTION
This pr supports both to_static and amp, and has been verified at petrv2_vovnet_gridmask_p4_800x320_dn_amp.yml.
Note, this pr is related to https://github.com/PaddlePaddle/Paddle/pull/52739