### PR TITLE
Toward Devkit Consistency

### DIFF
--- a/paddle3d/apis/checkpoint.py
+++ b/paddle3d/apis/checkpoint.py
@@ -175,6 +175,13 @@ class Checkpoint(CheckpointABC):
         os.makedirs(dirname, exist_ok=True)
         paddle.save(params_dict, params_path)
 
+        # Currently we save the *latest* model as the *best* model
+        best_model_path = os.path.join(self.rootdir, 'best_model')
+        if not os.path.exists(best_model_path):
+            os.makedirs(best_model_path)
+        paddle.save(params_dict, os.path.join(best_model_path,
+                                              'model.pdparams'))
+
         if ema_model is not None:
             assert isinstance(ema_model,
                               dict), ("ema_model is not a instance of dict, "

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ paddledet
 paddleseg
 pyquaternion
 pyyaml
-pillow<=8.3.2
+pillow
 rarfile
 scikit-image
 scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     author='PaddlePaddle Author',
     author_email='',
     install_requires=REQUIRED_PACKAGES,
-    packages=find_packages(),
+    packages=find_packages(include=['paddle3d', 'paddle3d.*']),
     package_data={
         'paddle3d.ops': get_cpp_files('paddle3d/ops'),
         'paddle3d.thirdparty': get_all_files('paddle3d/thirdparty')


### PR DESCRIPTION
## 目标

修改代码以提升PaddleCV套件一致性，同时适配X项目。修改后，套件应满足如下一致性要求：

1. 将训练过程中最优（一般是验证集上精度最高）的模型权重存储在输出目录的`best_model`子目录中，文件命名为`model.pdparams`。与之相配套的优化器参数（如果存储的话）文件命名为`model.pdopt`，也存储在该目录中。
2. 支持将训练、验证过程中VisualDL产生的.log格式日志文件保存在输出目录中（无嵌套子目录）。
3. 套件根目录存在`requirements.txt`文件，指定使用套件基础功能需要的依赖。在套件根目录可通过`pip install .`或`pip install -e .`方式（至少其中一种）安装套件核心库。
4. 对于模型导出功能，默认支持或通过命令行选项/配置文件等手段支持导出为FD格式。『FD格式』的导出结果通常包含如下文件：
- `inference.pdiparams`：保存权重参数。
- `inference.pdiparams.info`：保存与参数有关的额外信息。
- `inference.pdmodel`：保存模型结构描述信息。
- （可选）`inference.yml`：预处理配置文件。

## 代码变动

1. 【一致性提升】在存储检查点时将最新的模型权重作为最优权重存储，以满足一致性要求1（考虑到目前Paddle3D缺乏判别best model的手段）。
2. 【功能增强】使`setup.py`仅安装`paddle3d`目录中的内容，以避免其它非关键目录（若其中也包含`__init__.py`，则被识别为regular package）也一并被安装，并导致预期外的错误。

## 其它变动

1. 【功能增强】对Pillow版本不加限制，以便用户能够使用最新版本Pillow。

## 遗留问题
1. 对于代码变动1，**尚未更新相关文档**。若此PR合入，可能需要套件同学进行更新。
2. 目前`best_model`目录中尚未存储`model.pdopt`，尽管后者是可存储的。不过目前的实现也未违背一致性要求1。后续可考虑追加存储优化器参数。

