### PR TITLE
Fix Symbolic Links Not Overwritten

### DIFF
--- a/paddle3d/apis/checkpoint.py
+++ b/paddle3d/apis/checkpoint.py
@@ -179,16 +179,18 @@ class Checkpoint(CheckpointABC):
         best_model_path = os.path.join(self.rootdir, 'best_model')
         if not os.path.exists(best_model_path):
             os.makedirs(best_model_path)
+        tgt_path = os.path.join(best_model_path, 'model.pdparams')
+        if os.path.exists(tgt_path):
+            # Overwrite the existing best model
+            os.remove(tgt_path)
         try:
-            os.symlink(params_path,
-                       os.path.join(best_model_path, 'model.pdparams'))
+            os.symlink(params_path, tgt_path)
         except OSError:
             # On Windows with Developer Mode disabled, OSError is raised
             # when os.symlink is called by an unprivileged user.
             # In such cases, we make a copy of the source model.
             # We do not preserve the metadata.
-            shutil.copyfile(params_path,
-                            os.path.join(best_model_path, 'model.pdparams'))
+            shutil.copyfile(params_path, tgt_path)
 
         if ema_model is not None:
             assert isinstance(ema_model,


### PR DESCRIPTION
修复`best_model/model.pdparams`为符号链接、第二次存储时出错的情况（`os.symlink`无法自动覆盖旧的符号链接）。