### PR TITLE
fix ips printing problem

### DIFF
--- a/paddle3d/apis/trainer.py
+++ b/paddle3d/apis/trainer.py
@@ -307,6 +307,7 @@ class Trainer:
         while self.cur_iter < self.iters:
 
             for sample in self.train_dataloader:
+                timer.update()
                 if self.cur_iter == 1 and self.do_bind and int(
                         os.environ.get('FLAGS_selected_gpus', 0)) == 0:
                     test_cmd = "j=0 | j=$(( $j + 1 ))"

--- a/paddle3d/utils/timer.py
+++ b/paddle3d/utils/timer.py
@@ -27,6 +27,8 @@ class Timer:
         self._moving_speed = None
         self.momentum = momentum
         self.total_samples = 0
+        self._moving_samples = 0
+        self._moving_time = 0
 
     def step(self, num_samples=None):
         """
@@ -44,10 +46,15 @@ class Timer:
                     1 - self.momentum) * iter_speed
 
             self.elasped_time += iter_speed
+            self._moving_time += iter_speed
             if num_samples:
                 self.total_samples += num_samples
+                self._moving_samples += num_samples
 
         self.last_time = now
+
+    def update(self):
+        self.last_time = time.time()
 
     @property
     def speed(self):
@@ -62,7 +69,10 @@ class Timer:
     def ips(self):
         if not self.total_samples or self.cur_iter == 0:
             return 0
-        return float(self.total_samples) / self.elasped_time
+        moving_ips = float(self._moving_samples) / self._moving_time
+        self._moving_samples = 0
+        self._moving_time = 0
+        return moving_ips
 
     @property
     def eta(self):


### PR DESCRIPTION
修复训练时的ips打印不准确的问题，原因时之前将eval时间记入训练时间进行ips计算。