### PR TITLE
【benchmark】add max_mem_reserved for benchmark 

### DIFF
--- a/paddle3d/apis/trainer.py
+++ b/paddle3d/apis/trainer.py
@@ -382,13 +382,15 @@ class Trainer:
                         value=lr,
                         step=self.cur_iter)
                     max_mem_reserved = paddle.device.cuda.max_memory_reserved()
-                    max_mem_allocated = paddle.device.cuda.max_memory_allocated()
+                    max_mem_allocated = paddle.device.cuda.max_memory_allocated(
+                    )
                     self.logger.info(
                         '[TRAIN] epoch={}/{}, iter={}/{} {}, lr={:.6f}, batch_cost: {:.6f} sec, '
                         'ips: {:.6f} images/s | ETA {}, max_mem_reserved: {} B, max_mem_allocated: {} B'
                         .format(self.cur_epoch, self.epochs, self.cur_iter,
                                 self.iters, loss_log, lr, timer.speed,
-                                timer.ips, timer.eta, max_mem_reserved, max_mem_allocated))
+                                timer.ips, timer.eta, max_mem_reserved,
+                                max_mem_allocated))
 
                     losses_sum.clear()
 

--- a/paddle3d/apis/trainer.py
+++ b/paddle3d/apis/trainer.py
@@ -381,12 +381,14 @@ class Trainer:
                         tag='Training/learning_rate',
                         value=lr,
                         step=self.cur_iter)
-
+                    max_mem_reserved = paddle.device.cuda.max_memory_reserved()
+                    max_mem_allocated = paddle.device.cuda.max_memory_allocated()
                     self.logger.info(
-                        '[TRAIN] epoch={}/{}, iter={}/{} {}, lr={:.6f}, batch_cost: {:.6f} sec, ips: {:.6f} images/s | ETA {}'
+                        '[TRAIN] epoch={}/{}, iter={}/{} {}, lr={:.6f}, batch_cost: {:.6f} sec, '
+                        'ips: {:.6f} images/s | ETA {}, max_mem_reserved: {} B, max_mem_allocated: {} B'
                         .format(self.cur_epoch, self.epochs, self.cur_iter,
                                 self.iters, loss_log, lr, timer.speed,
-                                timer.ips, timer.eta))
+                                timer.ips, timer.eta, max_mem_reserved, max_mem_allocated))
 
                     losses_sum.clear()
 


### PR DESCRIPTION
训练benchmark 使用 API paddle.device.cuda.max_memory_reserved() 收集模型训练时的显存占用，因此本PR 修改 benchmark 打印日志部分，新增 max_mem_reserved max_mem_allocated 指标打印；如下：

2023-11-21 14:33:01,161 -     INFO - [TRAIN] epoch=1/1, iter=17/100 , total_loss=8.011797, lr=0.000100, batch_cost: 1.006130 sec, ips: 3.688496 images/s | ETA 00:01:28, max_mem_reserved: 21461481472 B, max_mem_allocated: 18893852672 B