### PR TITLE
Fix Petr3D AMP O2 training

### DIFF
--- a/paddle3d/apis/trainer.py
+++ b/paddle3d/apis/trainer.py
@@ -251,6 +251,19 @@ class Trainer:
             scaler_cfg_.update(**amp_cfg.pop('scaler', dict()))
             self.scaler = paddle.amp.GradScaler(**scaler_cfg_)
 
+            if type(self.model).__name__ in ["Petr3D"]:
+                _, self.optimizer = paddle.amp.decorate(
+                    [self.model.backbone, self.model.neck],
+                    self.optimizer,
+                    level=amp_cfg.get("level", "O1"),
+                    dtype=amp_cfg.get("dtype", "float16"))
+            else:
+                _, self.optimizer = paddle.amp.decorate(
+                    self.model,
+                    self.optimizer,
+                    level=amp_cfg.get("level", "O1"),
+                    dtype=amp_cfg.get("dtype", "float16"))
+
             amp_cfg.pop('use_amp', False)
             self.amp_cfg = amp_cfg
 


### PR DESCRIPTION
Fix Petr3D AMP O2 training
想跑Petr3D AMP O2训练还需要将paddle3d/apis/pipeline.py的apply_to_static函数的to_static添加full_graph=True参数，使得模型在AST模式下运行，在SOT下该模型还有问题